### PR TITLE
Skip properties whose propertyInfo value is null

### DIFF
--- a/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
+﻿using System;
+using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -29,7 +30,6 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption
                     if (property.ClrType == typeof(string) && !IsDiscriminator(property))
                     {
                         object[] attributes = property.PropertyInfo.GetCustomAttributes(typeof(EncryptedAttribute), false);
-
                         if (attributes.Any())
                             property.SetValueConverter(encryptionConverter);
                     }
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption
 
         private static bool IsDiscriminator(IMutableProperty property)
         {
-            return property.Name == "Discriminator" && property.PropertyInfo == null;
+            return property.Name == "Discriminator" || property.PropertyInfo == null;
         }
     }
 }


### PR DESCRIPTION
After doing some troubleshooting, I think there is a bug in the extension method, it appears that in the process of reading the properties from entities, some properties which are not discriminators also have PropertyInfo as null, in my case, it was owned, classes. ( They have some sort of ID).

This PR would fix this [issue](https://github.com/Eastrall/EntityFrameworkCore.DataEncryption/issues/10)