### PR TITLE
Dynamic IV per field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 3.0.100
+dotnet: 3.1.403
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
     name: ".NET Core 3 (Mac: OS X)"
       
 script:
-  - dotnet build ./src/$PROJECT_NAME/$PROJECT_NAME.csproj -c Release -f netstandard2.1
-  - dotnet test ./test/$PROJECT_NAME.Test/$PROJECT_NAME.Test.csproj -c Release -f netcoreapp3.0 /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[xunit*]*"
+  - dotnet build ./src/$PROJECT_NAME/$PROJECT_NAME.csproj -c Release
+  - dotnet test ./test/$PROJECT_NAME.Test/$PROJECT_NAME.Test.csproj -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[xunit*]*"
 
 after_script:
   - bash <(curl -s https://codecov.io/bash) 

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Filipe GOMES PEIXOTO</Authors>
     <PackageId>EntityFrameworkCore.DataEncryption</PackageId>
     <PackageProjectUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption</PackageProjectUrl>
@@ -13,12 +13,13 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>entity-framework-core, extensions, dotnet-core, dotnet, encryption, fluent-api</PackageTags>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <PackageIcon>icon.png</PackageIcon>
-    <Copyright>Filipe GOMES PEIXOTO © 2019</Copyright>
+    <Copyright>Filipe GOMES PEIXOTO © 2019 - 2020</Copyright>
     <Description>A plugin for Microsoft.EntityFrameworkCore to add support of encrypted fields using built-in or custom encryption providers.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>- Add support for Entity Framework Core 3</PackageReleaseNotes>
+    <PackageReleaseNotes>- Remove initializationVector parameter from `AesProvider` constructor.
+- Apply unique IV for each row.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
     <Version>2.0.0</Version>
@@ -23,8 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
@@ -19,7 +19,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption
         public static void UseEncryption(this ModelBuilder modelBuilder, IEncryptionProvider encryptionProvider)
         {
             if (encryptionProvider == null)
+            {
                 return;
+            }
 
             var encryptionConverter = new EncryptionConverter(encryptionProvider);
 
@@ -31,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption
                     {
                         object[] attributes = property.PropertyInfo.GetCustomAttributes(typeof(EncryptedAttribute), false);
                         if (attributes.Any())
+                        {
                             property.SetValueConverter(encryptionConverter);
+                        }
                     }
                 }
             }

--- a/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
+﻿using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using System;
 using System.ComponentModel.DataAnnotations;

--- a/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption
         {
             if (encryptionProvider == null)
             {
-                return;
+                throw new ArgumentNullException(nameof(encryptionProvider), "Cannot initialize encryption with a null provider.");
             }
 
             var encryptionConverter = new EncryptionConverter(encryptionProvider);

--- a/src/EntityFrameworkCore.DataEncryption/Providers/AesKeyInfo.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Providers/AesKeyInfo.cs
@@ -24,8 +24,8 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Providers
         /// <param name="iv">AES initialization vector.</param>
         internal AesKeyInfo(byte[] key, byte[] iv)
         {
-            this.Key = key;
-            this.IV = iv;
+            Key = key;
+            IV = iv;
         }
 
         /// <summary>
@@ -33,20 +33,20 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Providers
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
-        public bool Equals(AesKeyInfo other) => (this.Key, this.IV) == (other.Key, other.IV);
+        public bool Equals(AesKeyInfo other) => (Key, IV) == (other.Key, other.IV);
 
         /// <summary>
         /// Determines whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public override bool Equals(object obj) => (obj is AesKeyInfo keyInfo) && this.Equals(keyInfo);
+        public override bool Equals(object obj) => (obj is AesKeyInfo keyInfo) && Equals(keyInfo);
 
         /// <summary>
         /// Calculates the hash code for the current <see cref="AesKeyInfo"/> instance.
         /// </summary>
         /// <returns></returns>
-        public override int GetHashCode() => (this.Key, this.IV).GetHashCode();
+        public override int GetHashCode() => (Key, IV).GetHashCode();
 
         /// <summary>
         /// Determines whether the current <see cref="AesKeyInfo"/> is equal to another <see cref="AesKeyInfo"/>.

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
@@ -25,10 +25,10 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 
         public AuthorEntity(string firstName, string lastName, int age)
         {
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Age = age;
-            this.Books = new List<BookEntity>();
+            FirstName = firstName;
+            LastName = lastName;
+            Age = age;
+            Books = new List<BookEntity>();
         }
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
@@ -24,8 +24,8 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 
         public BookEntity(string name, int numberOfPages)
         {
-            this.Name = name;
-            this.NumberOfPages = numberOfPages;
+            Name = name;
+            NumberOfPages = numberOfPages;
         }
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContext.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContext.cs
@@ -15,9 +15,9 @@
         public DatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
             : base(options)
         {
-            this._encryptionProvider = encryptionProvider;
+            _encryptionProvider = encryptionProvider;
         }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.UseEncryption(this._encryptionProvider);
+            => modelBuilder.UseEncryption(_encryptionProvider);
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContext.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContext.cs
@@ -18,6 +18,8 @@
             _encryptionProvider = encryptionProvider;
         }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.UseEncryption(_encryptionProvider);
+        {
+            modelBuilder.UseEncryption(_encryptionProvider);
+        }
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
@@ -17,10 +17,10 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         /// </summary>
         public DatabaseContextFactory()
         {
-            this._connection = new SqliteConnection(DatabaseConnectionString);
-            this._connection.Open();
+            _connection = new SqliteConnection(DatabaseConnectionString);
+            _connection.Open();
 
-            using (var dbContext = new DatabaseContext(this.CreateOptions<DatabaseContext>()))
+            using (var dbContext = new DatabaseContext(CreateOptions<DatabaseContext>()))
                 dbContext.Database.EnsureCreated();
         }
 
@@ -33,9 +33,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         public TContext CreateContext<TContext>(IEncryptionProvider provider = null) where TContext : DbContext
         {
             if (provider == null)
-                return Activator.CreateInstance(typeof(TContext), this.CreateOptions<TContext>()) as TContext;
+                return Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>()) as TContext;
 
-            return Activator.CreateInstance(typeof(TContext), this.CreateOptions<TContext>(), provider) as TContext;
+            return Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
         }
 
         /// <summary>
@@ -51,9 +51,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         /// </summary>
         public void Dispose()
         {
-            if (this._connection != null)
+            if (_connection != null)
             {
-                this._connection.Dispose();
+                _connection.Dispose();
             }
         }
     }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
@@ -19,9 +19,6 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         {
             _connection = new SqliteConnection(DatabaseConnectionString);
             _connection.Open();
-
-            using (var dbContext = new DatabaseContext(CreateOptions<DatabaseContext>()))
-                dbContext.Database.EnsureCreated();
         }
 
         /// <summary>
@@ -32,10 +29,11 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         /// <returns></returns>
         public TContext CreateContext<TContext>(IEncryptionProvider provider = null) where TContext : DbContext
         {
-            if (provider == null)
-                return Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>()) as TContext;
+            var context = Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
 
-            return Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
+            context.Database.EnsureCreated();
+
+            return context;
         }
 
         /// <summary>

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -15,11 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.*" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.*" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,29 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
-
     <RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.*" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.*" Condition="'$(TargetFramework)' == 'netcoreapp3.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
         {
             string input = StringHelper.RandomString(20);
             AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
-            var provider = new AesProvider(encryptionKeyInfo.Key, encryptionKeyInfo.IV);
+            var provider = new AesProvider(encryptionKeyInfo.Key);
 
             string encryptedData = provider.Encrypt(input);
             Assert.NotNull(encryptedData);
@@ -66,25 +66,25 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
         [Fact]
         public void EncryptUsingAes128Provider()
         {
-            this.ExecuteAesEncryptionTest<Aes128EncryptedDatabaseContext>(AesKeySize.AES128Bits);
+            ExecuteAesEncryptionTest<Aes128EncryptedDatabaseContext>(AesKeySize.AES128Bits);
         }
 
         [Fact]
         public void EncryptUsingAes192Provider()
         {
-            this.ExecuteAesEncryptionTest<Aes192EncryptedDatabaseContext>(AesKeySize.AES192Bits);
+            ExecuteAesEncryptionTest<Aes192EncryptedDatabaseContext>(AesKeySize.AES192Bits);
         }
 
         [Fact]
         public void EncryptUsingAes256Provider()
         {
-            this.ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
+            ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
         }
 
         private void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
         {
             AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(aesKeyType);
-            var provider = new AesProvider(encryptionKeyInfo.Key, encryptionKeyInfo.IV, CipherMode.CBC, PaddingMode.Zeros);
+            var provider = new AesProvider(encryptionKeyInfo.Key, CipherMode.CBC, PaddingMode.Zeros);
             var author = new AuthorEntity("John", "Doe", 42)
             {
                 Books = new List<BookEntity>()
@@ -93,10 +93,6 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
                     new BookEntity("Dolor sit amet", 390)
                 }
             };
-            string authorEncryptedFirstName = provider.Encrypt(author.FirstName);
-            string authorEncryptedLastName = provider.Encrypt(author.LastName);
-            string firstBookEncryptedName = provider.Encrypt(author.Books.First().Name);
-            string lastBookEncryptedName = provider.Encrypt(author.Books.Last().Name);
 
             using (var contextFactory = new DatabaseContextFactory())
             {
@@ -105,21 +101,6 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
                 {
                     dbContext.Authors.Add(author);
                     dbContext.SaveChanges();
-                }
-
-                // Read encrypted data from normal context and compare with encrypted data.
-                using (var dbContext = contextFactory.CreateContext<DatabaseContext>())
-                {
-                    var authorFromDb = dbContext.Authors.Include(x => x.Books).FirstOrDefault();
-
-                    Assert.NotNull(authorFromDb);
-                    Assert.Equal(authorEncryptedFirstName, authorFromDb.FirstName);
-                    Assert.Equal(authorEncryptedLastName, authorFromDb.LastName);
-                    Assert.NotNull(authorFromDb.Books);
-                    Assert.NotEmpty(authorFromDb.Books);
-                    Assert.Equal(2, authorFromDb.Books.Count);
-                    Assert.Equal(firstBookEncryptedName, authorFromDb.Books.First().Name);
-                    Assert.Equal(lastBookEncryptedName, authorFromDb.Books.Last().Name);
                 }
 
                 // Read decrypted data and compare with original data

--- a/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
 using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
 using Microsoft.EntityFrameworkCore.DataEncryption.Test.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -61,6 +62,15 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
             Assert.True(encryptionKeyInfo1 != encryptionKeyInfo2);
             Assert.True(encryptionKeyInfo1.GetHashCode() != encryptionKeyInfo2.GetHashCode());
             Assert.False(encryptionKeyInfo1.Equals(0));
+        }
+
+        [Fact]
+        public void CreateDataContextWithoutProvider()
+        {
+            using (var contextFactory = new DatabaseContextFactory())
+            {
+                Assert.Throws<ArgumentNullException>(() => contextFactory.CreateContext<SimpleEncryptedDatabaseContext>());
+            }
         }
 
         [Fact]
@@ -135,6 +145,12 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
         public class Aes256EncryptedDatabaseContext : DatabaseContext
         {
             public Aes256EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider) { }
+        }
+
+        public class SimpleEncryptedDatabaseContext : DatabaseContext
+        {
+            public SimpleEncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
                 : base(options, encryptionProvider) { }
         }
     }


### PR DESCRIPTION
## Breaking changes

- Drop support of EF Core 2.X
- Remove the `initializationVector` parameter when setting up an `AesProvider`.
> Each encrypted field generate a unique IV which is stored in the first 16 bytes of the encrypted content