### PR TITLE
Data migration

### DIFF
--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -16,11 +16,17 @@
     <PackageTags>entity-framework-core, extensions, dotnet-core, dotnet, encryption, fluent-api</PackageTags>
     <LangVersion>8.0</LangVersion>
     <PackageIcon>icon.png</PackageIcon>
-    <Copyright>Filipe GOMES PEIXOTO © 2019 - 2020</Copyright>
+    <Copyright>Filipe GOMES PEIXOTO © 2019 - 2021</Copyright>
     <Description>A plugin for Microsoft.EntityFrameworkCore to add support of encrypted fields using built-in or custom encryption providers.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReleaseNotes>- Remove initializationVector parameter from `AesProvider` constructor.
 - Apply unique IV for each row.</PackageReleaseNotes>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +39,10 @@
       <PackagePath></PackagePath>
     </None>
     <None Include="Resources/icon.png" Pack="true" Visible="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\PublishProfiles\" />
   </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.DataEncryption/Migration/DataMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/DataMigrator.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal;
 using Microsoft.EntityFrameworkCore.DataEncryption.Providers.Obsolete;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -28,17 +27,19 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
         /// <summary>
         /// Process a data migration to migrate plain text data into encrypted data.
         /// </summary>
-        public void MigrateOriginalToEncrypted()
+        /// <param name="encryptionProvider">Encryption provider.</param>
+        public void MigrateOriginalToEncrypted(IEncryptionProvider encryptionProvider)
         {
-            throw new NotImplementedException();
+            MigrateData(new OriginalToEncryptedMigrator(encryptionProvider));
         }
 
         /// <summary>
         /// Process a data migration to migrate encryted data into plain text data.
         /// </summary>
-        public void MigrateEncryptedToOriginal()
+        /// <param name="encryptionProvider">Encryption provider.</param>
+        public void MigrateEncryptedToOriginal(IEncryptionProvider encryptionProvider)
         {
-            throw new NotImplementedException();
+            MigrateData(new EncryptedToOriginalMigrator(encryptionProvider));
         }
 
         /// <summary>

--- a/src/EntityFrameworkCore.DataEncryption/Migration/DataMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/DataMigrator.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers.Obsolete;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
+{
+    /// <summary>
+    /// Provides a mechanism to migrate data.
+    /// </summary>
+    public sealed class DataMigrator<TContext> where TContext : DbContext
+    {
+        private readonly TContext _databaseContext;
+
+        /// <summary>
+        /// Creates a new <see cref="DataMigrator{TContext}"/> instance.
+        /// </summary>
+        /// <param name="databaseContext">Database context.</param>
+        public DataMigrator(TContext databaseContext)
+        {
+            _databaseContext = databaseContext;
+        }
+
+        /// <summary>
+        /// Process a data migration to migrate plain text data into encrypted data.
+        /// </summary>
+        public void MigrateOriginalToEncrypted()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Process a data migration to migrate encryted data into plain text data.
+        /// </summary>
+        public void MigrateEncryptedToOriginal()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Migrates the data from V1 to V2.
+        /// </summary>
+        /// <param name="encryptionProvider">V2 encryption provider</param>
+        /// <param name="encryptionKey">V1 encryption key.</param>
+        /// <param name="initializationVector">V1 initialization vector.</param>
+        /// <param name="mode">Mode for operation used in the symetric encryption.</param>
+        /// <param name="padding">Padding mode used in the symetric encryption.</param>
+        public void MigrateAesV1ToV2(IEncryptionProvider encryptionProvider, byte[] encryptionKey, byte[] initializationVector, CipherMode mode = CipherMode.CBC, PaddingMode padding = PaddingMode.PKCS7)
+        {
+            var aesProviderV1 = new AesProviderV1(encryptionKey, initializationVector, mode, padding);
+            var migrator = new V1ToV2DataMigrator(aesProviderV1, encryptionProvider);
+            
+            MigrateData(migrator);
+        }
+
+        /// <summary>
+        /// Procress the data migration according to the given data migrator.
+        /// </summary>
+        /// <param name="dataMigrator"></param>
+        private void MigrateData(IDataMigrator dataMigrator)
+        {
+            IEnumerable<EncryptedEntity> encryptedEntities = _databaseContext.Model.GetEntityTypes()
+                .Select(x => x.ClrType)
+                .Where(x => x.GetProperties().Any(p => p.GetCustomAttribute<EncryptedAttribute>() != null))
+                .Select(x => 
+                    new EncryptedEntity(
+                        x,
+                        x.GetProperties().Where(p => p.GetCustomAttribute<EncryptedAttribute>() != null)
+                    )
+                );
+
+            dataMigrator.Migrate(_databaseContext, encryptedEntities);
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/EncryptedEntity.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/EncryptedEntity.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
+{
+    [DebuggerDisplay("{EntityType.Name}")]
+    internal class EncryptedEntity
+    {
+        public Type EntityType { get; }
+
+        public IEnumerable<PropertyInfo> EncryptedProperties { get; }
+
+        public EncryptedEntity(Type entityType, IEnumerable<PropertyInfo> encryptedProperties)
+        {
+            EntityType = entityType;
+            EncryptedProperties = encryptedProperties;
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/IDataMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/IDataMigrator.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
+{
+    internal interface IDataMigrator
+    {
+        void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities);
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/DataMigratorBase.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/DataMigratorBase.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
+{
+    internal class DataMigratorBase
+    {
+        protected DataMigratorBase()
+        {
+        }
+
+        /// <summary>
+        /// Gets the DbSet based on the given entity type.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="entityType"></param>
+        /// <returns></returns>
+        protected IQueryable<object> GetDbSet(DbContext context, Type entityType)
+        {
+            return (IQueryable<object>)context.GetType()
+                .GetMethods()
+                .FirstOrDefault(x => x.Name.StartsWith("Set"))
+                .MakeGenericMethod(entityType)
+                .Invoke(context, null);
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/EncryptedToOriginalMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/EncryptedToOriginalMigrator.cs
@@ -4,6 +4,13 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
 {
     internal class EncryptedToOriginalMigrator : IDataMigrator
     {
+        private readonly IEncryptionProvider _encryptionProvider;
+
+        public EncryptedToOriginalMigrator(IEncryptionProvider encryptionProvider)
+        {
+            _encryptionProvider = encryptionProvider;
+        }
+
         public void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities)
         {
             throw new System.NotImplementedException();

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/EncryptedToOriginalMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/EncryptedToOriginalMigrator.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
+{
+    internal class EncryptedToOriginalMigrator : IDataMigrator
+    {
+        public void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/EncryptedToOriginalMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/EncryptedToOriginalMigrator.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
 {
-    internal class EncryptedToOriginalMigrator : IDataMigrator
+    internal class EncryptedToOriginalMigrator : DataMigratorBase, IDataMigrator
     {
         private readonly IEncryptionProvider _encryptionProvider;
 
@@ -13,7 +15,39 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
 
         public void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities)
         {
-            throw new System.NotImplementedException();
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (encryptedEntities is null)
+            {
+                throw new ArgumentNullException(nameof(encryptedEntities));
+            }
+
+            foreach (EncryptedEntity encryptedEntity in encryptedEntities)
+            {
+                IEnumerable<object> entities = GetDbSet(context, encryptedEntity.EntityType);
+
+                foreach (object entity in entities)
+                {
+                    foreach (PropertyInfo entityProperty in encryptedEntity.EncryptedProperties)
+                    {
+                        string sourceValue = entityProperty.GetValue(entity)?.ToString();
+
+                        if (sourceValue is null)
+                        {
+                            continue;
+                        }
+
+                        string newValue = _encryptionProvider.Decrypt(sourceValue);
+
+                        entityProperty.SetValue(entity, newValue);
+                    }
+                }
+            }
+
+            context.SaveChanges();
         }
     }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/OriginalToEncryptedMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/OriginalToEncryptedMigrator.cs
@@ -45,9 +45,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
                         entityProperty.SetValue(entity, newValue);
                     }
                 }
-
-                context.SaveChanges();
             }
+
+            context.SaveChanges();
         }
     }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/OriginalToEncryptedMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/OriginalToEncryptedMigrator.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
+{
+    internal class OriginalToEncryptedMigrator : IDataMigrator
+    {
+        public void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/OriginalToEncryptedMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/OriginalToEncryptedMigrator.cs
@@ -1,12 +1,53 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
 {
-    internal class OriginalToEncryptedMigrator : IDataMigrator
+    internal class OriginalToEncryptedMigrator : DataMigratorBase, IDataMigrator
     {
+        private readonly IEncryptionProvider _encryptionProvider;
+
+        public OriginalToEncryptedMigrator(IEncryptionProvider encryptionProvider)
+        {
+            _encryptionProvider = encryptionProvider;
+        }
+
         public void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities)
         {
-            throw new System.NotImplementedException();
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (encryptedEntities is null)
+            {
+                throw new ArgumentNullException(nameof(encryptedEntities));
+            }
+
+            foreach (EncryptedEntity encryptedEntity in encryptedEntities)
+            {
+                IEnumerable<object> entities = GetDbSet(context, encryptedEntity.EntityType);
+
+                foreach (object entity in entities)
+                {
+                    foreach (PropertyInfo entityProperty in encryptedEntity.EncryptedProperties)
+                    {
+                        string sourceValue = entityProperty.GetValue(entity)?.ToString();
+
+                        if (sourceValue is null)
+                        {
+                            continue;
+                        }
+
+                        string newValue = _encryptionProvider.Encrypt(sourceValue);
+
+                        entityProperty.SetValue(entity, newValue);
+                    }
+                }
+
+                context.SaveChanges();
+            }
         }
     }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/V1ToV2DataMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/V1ToV2DataMigrator.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
+{
+    internal class V1ToV2DataMigrator : DataMigratorBase, IDataMigrator
+    {
+        private readonly IEncryptionProvider _sourceEncryptionProvider;
+        private readonly IEncryptionProvider _encryptionProvider;
+
+        /// <summary>
+        /// Creates a new <see cref="V1ToV2DataMigrator"/> instance with the V1 encryption provider and the new encryption provider.
+        /// </summary>
+        /// <param name="sourceEncryptionProvider">V1 encryption provider.</param>
+        /// <param name="encryptionProvider">V2 encryption provider.</param>
+        public V1ToV2DataMigrator(IEncryptionProvider sourceEncryptionProvider, IEncryptionProvider encryptionProvider)
+        {
+            _sourceEncryptionProvider = sourceEncryptionProvider ?? throw new ArgumentNullException(nameof(sourceEncryptionProvider));
+            _encryptionProvider = encryptionProvider ?? throw new ArgumentNullException(nameof(encryptionProvider));
+        }
+
+        public void Migrate(DbContext context, IEnumerable<EncryptedEntity> encryptedEntities)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (encryptedEntities is null)
+            {
+                throw new ArgumentNullException(nameof(encryptedEntities));
+            }
+
+            foreach (EncryptedEntity encryptedEntity in encryptedEntities)
+            {
+                var entities = GetDbSet(context, encryptedEntity.EntityType);
+
+                foreach (object entity in entities)
+                {
+                    foreach (PropertyInfo entityProperty in encryptedEntity.EncryptedProperties)
+                    {
+                        string sourceValue = entityProperty.GetValue(entity)?.ToString();
+
+                        if (sourceValue is null)
+                        {
+                            continue;
+                        }
+
+                        string decryptedValue = _sourceEncryptionProvider.Decrypt(sourceValue);
+                        string newValue = _encryptionProvider.Encrypt(decryptedValue);
+
+                        entityProperty.SetValue(entity, newValue);
+                    }
+                }
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/Internal/V1ToV2DataMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/Internal/V1ToV2DataMigrator.cs
@@ -53,9 +53,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration.Internal
                         entityProperty.SetValue(entity, newValue);
                     }
                 }
-
-                context.SaveChanges();
             }
+
+            context.SaveChanges();
         }
     }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Properties/AssemblyInfo.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.EntityFrameworkCore.Encryption.Test")]

--- a/src/EntityFrameworkCore.DataEncryption/Providers/Obsolete/AesProviderV1.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Providers/Obsolete/AesProviderV1.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Providers.Obsolete
+{
+    /// <summary>
+    /// Implements the Advanced Encryption Standard (AES) symmetric algorithm.
+    /// </summary>
+    /// <remarks>
+    /// This class is now obsolete and use only for migrating data from V1 to V2 format.
+    /// </remarks>
+    internal class AesProviderV1 : IEncryptionProvider
+    {
+        private const int AesBlockSize = 128;
+        private readonly byte[] _key;
+        private readonly byte[] _initializationVector;
+        private readonly CipherMode _mode;
+        private readonly PaddingMode _padding;
+
+        /// <summary>
+        /// Creates a new <see cref="AesProvider"/> instance used to perform symetric encryption and decryption on strings.
+        /// </summary>
+        /// <param name="key">AES key used for the symetric encryption.</param>
+        /// <param name="initializationVector">AES Initialization Vector used for the symetric encryption.</param>
+        /// <param name="mode">Mode for operation used in the symetric encryption.</param>
+        /// <param name="padding">Padding mode used in the symetric encryption.</param>
+        public AesProviderV1(byte[] key, byte[] initializationVector, CipherMode mode = CipherMode.CBC, PaddingMode padding = PaddingMode.PKCS7)
+        {
+            _key = key;
+            _initializationVector = initializationVector;
+            _mode = mode;
+            _padding = padding;
+        }
+
+        /// <summary>
+        /// Encrypt a string using the AES algorithm.
+        /// </summary>
+        /// <param name="dataToEncrypt"></param>
+        /// <returns></returns>
+        public string Encrypt(string dataToEncrypt)
+        {
+            byte[] input = Encoding.UTF8.GetBytes(dataToEncrypt);
+            byte[] encrypted = null;
+
+            using (var aes = CreateNewAesEncryptor())
+            {
+                using var memoryStream = new MemoryStream();
+                using (var crypto = new CryptoStream(memoryStream, aes.CreateEncryptor(), CryptoStreamMode.Write))
+                    crypto.Write(input, 0, input.Length);
+
+                encrypted = memoryStream.ToArray();
+            }
+
+            return Convert.ToBase64String(encrypted);
+        }
+
+        /// <summary>
+        /// Decrypt a string using the AES algorithm.
+        /// </summary>
+        /// <param name="dataToDecrypt"></param>
+        /// <returns></returns>
+        public string Decrypt(string dataToDecrypt)
+        {
+            byte[] input = Convert.FromBase64String(dataToDecrypt);
+            string decrypted = string.Empty;
+
+            using (var aes = CreateNewAesEncryptor())
+            {
+                using var memoryStream = new MemoryStream(input);
+                using var crypto = new CryptoStream(memoryStream, aes.CreateDecryptor(), CryptoStreamMode.Read);
+                using var sr = new StreamReader(crypto);
+
+                decrypted = sr.ReadToEnd().Trim('\0');
+            }
+
+            return decrypted;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Aes"/> instance with the current configuration.
+        /// </summary>
+        /// <returns></returns>
+        private Aes CreateNewAesEncryptor()
+        {
+            var aes = Aes.Create();
+
+            aes.Mode = _mode;
+            aes.Padding = _padding;
+            aes.Key = _key;
+            aes.IV = _initializationVector;
+
+            return aes;
+        }
+
+        /// <summary>
+        /// Generates an AES key.
+        /// </summary>
+        /// <remarks>
+        /// The key size of the Aes encryption must be 128, 192 or 256 bits. 
+        /// Please check https://blogs.msdn.microsoft.com/shawnfa/2006/10/09/the-differences-between-rijndael-and-aes/ for more informations.
+        /// </remarks>
+        /// <param name="keySize">AES Key size</param>
+        /// <returns></returns>
+        public static AesKeyInfo GenerateKey(AesKeySize keySize)
+        {
+            var crypto = new AesCryptoServiceProvider
+            {
+                KeySize = (int)keySize,
+                BlockSize = AesBlockSize
+            };
+
+            crypto.GenerateKey();
+            crypto.GenerateIV();
+
+            return new AesKeyInfo(crypto.Key, crypto.IV);
+        }
+    }
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -9,6 +10,8 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
+
+        public Guid UniqueId { get; set; }
 
         [Required]
         [Encrypted]
@@ -29,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
             LastName = lastName;
             Age = age;
             Books = new List<BookEntity>();
+            UniqueId = Guid.NewGuid();
         }
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
@@ -8,6 +9,8 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
+
+        public Guid UniqueId { get; set; }
 
         [Required]
         [Encrypted]
@@ -26,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         {
             Name = name;
             NumberOfPages = numberOfPages;
+            UniqueId = Guid.NewGuid();
         }
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
@@ -9,15 +9,24 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
     /// </summary>
     public sealed class DatabaseContextFactory : IDisposable
     {
-        private const string DatabaseConnectionString = "DataSource=:memory:";
+        private const string InMemoryDatabaseConnectionString = "DataSource=:memory:";
+        private const string DatabaseConnectionString = "DataSource={0}";
         private readonly DbConnection _connection;
 
         /// <summary>
         /// Creates a new <see cref="DatabaseContextFactory"/> instance.
         /// </summary>
-        public DatabaseContextFactory()
+        public DatabaseContextFactory(string databaseName = null)
         {
-            _connection = new SqliteConnection(DatabaseConnectionString);
+            if (string.IsNullOrEmpty(databaseName))
+            {
+                _connection = new SqliteConnection(InMemoryDatabaseConnectionString);
+            }
+            else
+            {
+                _connection = new SqliteConnection(string.Format(DatabaseConnectionString, databaseName));
+            }
+
             _connection.Open();
         }
 
@@ -41,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
         /// </summary>
         /// <typeparam name="TContext"></typeparam>
         /// <returns></returns>
-        private DbContextOptions<TContext> CreateOptions<TContext>() where TContext : DbContext 
+        public DbContextOptions<TContext> CreateOptions<TContext>() where TContext : DbContext 
             => new DbContextOptionsBuilder<TContext>().UseSqlite(_connection).Options;
 
         /// <summary>

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/MigrationContext.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/MigrationContext.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
+{
+    public class MigrationContext : DbContext
+    {
+        private readonly IEncryptionProvider _encryptionProvider;
+
+        public DbSet<AuthorEntity> Authors { get; set; }
+
+        public DbSet<BookEntity> Books { get; set; }
+
+        public MigrationContext(DbContextOptions options)
+            : base(options)
+        { }
+
+        public MigrationContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+            : base(options)
+        {
+            _encryptionProvider = encryptionProvider;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            if (_encryptionProvider is not null)
+            {
+                modelBuilder.UseEncryption(_encryptionProvider);
+            }
+        }
+    }
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="32.0.2" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
@@ -1,0 +1,12 @@
+﻿using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+    public class EncryptedToOriginalMigratorTest : MigratorBaseTest
+    {
+        [Fact]
+        public void MigrateEncryptedToOriginalTest()
+        {
+        }
+    }
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
@@ -1,4 +1,11 @@
-﻿using Xunit;
+﻿using Microsoft.EntityFrameworkCore.DataEncryption;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 {
@@ -7,6 +14,78 @@ namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
         [Fact]
         public void MigrateEncryptedToOriginalTest()
         {
+            var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+            var provider = new AesProvider(aesKeys.Key);
+            string databaseName = Guid.NewGuid().ToString();
+
+            // Feed database with data.
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<EncryptedToOriginalMigrationEncryptedContext>(provider);
+
+                context.Authors.AddRange(Authors);
+                context.SaveChanges();
+            }
+
+            // Process data migration
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<EncryptedToOriginalMigrationTransitionContext>();
+                var migrator = new DataMigrator<EncryptedToOriginalMigrationTransitionContext>(context);
+
+                migrator.MigrateEncryptedToOriginal(provider);
+            }
+
+            // Assert if the context has been decrypted
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<EncryptedToOriginalMigrationContext>();
+                IEnumerable<AuthorEntity> authors = context.Authors.Include(x => x.Books);
+
+                foreach (AuthorEntity author in authors)
+                {
+                    AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+
+                    AssertAuthor(original, author);
+                }
+            }
+        }
+
+        private class EncryptedToOriginalMigrationContext : MigrationContext
+        {
+            public EncryptedToOriginalMigrationContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public EncryptedToOriginalMigrationContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider)
+            {
+            }
+        }
+
+        private class EncryptedToOriginalMigrationTransitionContext : MigrationContext
+        {
+            public EncryptedToOriginalMigrationTransitionContext(DbContextOptions options) : base(options)
+            {
+            }
+
+            public EncryptedToOriginalMigrationTransitionContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider)
+            {
+            }
+        }
+
+        private class EncryptedToOriginalMigrationEncryptedContext : MigrationContext
+        {
+            public EncryptedToOriginalMigrationEncryptedContext(DbContextOptions options) : base(options)
+            {
+            }
+
+            public EncryptedToOriginalMigrationEncryptedContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider)
+            {
+            }
         }
     }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
@@ -1,0 +1,41 @@
+﻿using Bogus;
+using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+    public class MigratorBaseTest
+    {
+        protected IEnumerable<AuthorEntity> Authors { get; }
+
+        protected MigratorBaseTest()
+        {
+            var faker = new Faker();
+            Authors = Enumerable.Range(0, faker.Random.Byte())
+                .Select(x => new AuthorEntity(faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Int(0, 90))
+                {
+                    Books = Enumerable.Range(0, 10).Select(y => new BookEntity(faker.Lorem.Sentence(), faker.Random.Int(100, 500))).ToList()
+                }).ToList();
+        }
+
+        protected void AssertAuthor(AuthorEntity expected, AuthorEntity actual)
+        {
+            Assert.NotNull(actual);
+            Assert.Equal(expected.FirstName, actual.FirstName);
+            Assert.Equal(expected.LastName, actual.LastName);
+            Assert.Equal(expected.Age, actual.Age);
+            Assert.Equal(expected.Books.Count, actual.Books.Count);
+
+            foreach (BookEntity actualBook in expected.Books)
+            {
+                BookEntity expectedBook = actual.Books.FirstOrDefault(x => x.UniqueId == actualBook.UniqueId);
+
+                Assert.NotNull(expectedBook);
+                Assert.Equal(expectedBook.Name, actualBook.Name);
+                Assert.Equal(expectedBook.NumberOfPages, actualBook.NumberOfPages);
+            }
+        }
+    }
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/OrigintalToEncryptedMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/OrigintalToEncryptedMigratorTest.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.EntityFrameworkCore.DataEncryption;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+    public class OrigintalToEncryptedMigratorTest : MigratorBaseTest
+    {
+        [Fact]
+        public void MigrateOriginalToEncryptedTest()
+        {
+            var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+            var provider = new AesProvider(aesKeys.Key);
+            string databaseName = Guid.NewGuid().ToString();
+
+            // Feed database with data.
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<MigrationRawOriginalContext>();
+
+                context.Authors.AddRange(Authors);
+                context.SaveChanges();
+            }
+
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<MigrationTransitionDbContext>();
+                var migrator = new DataMigrator<MigrationTransitionDbContext>(context);
+
+                migrator.MigrateOriginalToEncrypted(provider);
+            }
+
+            // Assert if the context has been encrypted
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<MigrationEncryptedContext>(provider);
+                IEnumerable<AuthorEntity> authors = context.Authors.Include(x => x.Books);
+
+                foreach (AuthorEntity author in authors)
+                {
+                    AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+
+                    AssertAuthor(original, author);
+                }
+            }
+
+            // Assert data context if raw data is encrypted
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<MigrationRawOriginalContext>(provider);
+                IEnumerable<AuthorEntity> authors = context.Authors.Include(x => x.Books);
+
+                foreach (AuthorEntity author in authors)
+                {
+                    AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+
+                    Assert.NotNull(original);
+                    Assert.Equal(original.FirstName, provider.Decrypt(author.FirstName));
+                    Assert.Equal(original.LastName, provider.Decrypt(author.LastName));
+                    Assert.Equal(original.Books.Count, author.Books.Count);
+
+                    foreach (BookEntity actualBook in author.Books)
+                    {
+                        BookEntity expectedBook = original.Books.FirstOrDefault(x => x.UniqueId == actualBook.UniqueId);
+
+                        Assert.NotNull(expectedBook);
+                        Assert.Equal(expectedBook.Name, provider.Decrypt(actualBook.Name));
+                        Assert.Equal(expectedBook.NumberOfPages, actualBook.NumberOfPages);
+                    }
+                }
+            }
+
+            File.Delete(databaseName);
+        }
+
+        private class MigrationRawOriginalContext : MigrationContext
+        {
+            public MigrationRawOriginalContext(DbContextOptions options) 
+                : base(options)
+            {
+            }
+
+            public MigrationRawOriginalContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null) 
+                : base(options, encryptionProvider)
+            {
+            }
+        }
+
+        private class MigrationTransitionDbContext : MigrationContext
+        {
+            public MigrationTransitionDbContext(DbContextOptions options) : base(options)
+            {
+            }
+
+            public MigrationTransitionDbContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider)
+            {
+            }
+        }
+
+        private class MigrationEncryptedContext : MigrationContext
+        {
+            public MigrationEncryptedContext(DbContextOptions options) : base(options)
+            {
+            }
+
+            public MigrationEncryptedContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null) 
+                : base(options, encryptionProvider)
+            {
+            }
+        }
+    }
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
@@ -1,5 +1,4 @@
-﻿using Bogus;
-using Microsoft.EntityFrameworkCore.DataEncryption;
+﻿using Microsoft.EntityFrameworkCore.DataEncryption;
 using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
 using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
 using Microsoft.EntityFrameworkCore.DataEncryption.Providers.Obsolete;
@@ -12,23 +11,8 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 {
-    public class V1ToV2MigratorTest
+    public class V1ToV2MigratorTest : MigratorBaseTest
     {
-        private readonly IEnumerable<AuthorEntity> _authors;
-
-        public V1ToV2MigratorTest()
-        {
-            var faker = new Faker();
-            _authors = Enumerable.Range(0, faker.Random.Byte())
-                .Select(x => new AuthorEntity(faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Int(0, 90))
-                {
-                    Books = Enumerable.Range(0, 10)
-                                .Select(y => new BookEntity(faker.Lorem.Sentence(), faker.Random.Int(100, 500))
-                                {
-                                }).ToList()
-                }).ToList();
-        }
-
         [Fact]
         public void MigrateV1ToV2Test()
         {
@@ -40,15 +24,15 @@ namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
             {
                 using var context = contextFactory.CreateContext<DatabaseContext>(new AesProviderV1(aesKeys.Key, aesKeys.IV));
 
-                context.Authors.AddRange(_authors);
+                context.Authors.AddRange(Authors);
                 context.SaveChanges();
             }
 
             // Process migration
             using (var contextFactory = new DatabaseContextFactory(databaseName))
             {
-                using var context = contextFactory.CreateContext<TransitionDbContext>();
-                var migrator = new DataMigrator<TransitionDbContext>(context);
+                using var context = contextFactory.CreateContext<MigrationTransitionDbContext>();
+                var migrator = new DataMigrator<MigrationTransitionDbContext>(context);
 
                 migrator.MigrateAesV1ToV2(new AesProvider(aesKeys.Key), aesKeys.Key, aesKeys.IV);
             }
@@ -60,35 +44,22 @@ namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 
                 foreach (AuthorEntity author in authors)
                 {
-                    AuthorEntity original = _authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+                    AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
 
-                    Assert.NotNull(original);
-                    Assert.Equal(original.FirstName, author.FirstName);
-                    Assert.Equal(original.LastName, author.LastName);
-                    Assert.Equal(original.Age, author.Age);
-                    Assert.Equal(original.Books.Count, author.Books.Count);
-
-                    foreach (BookEntity book in author.Books)
-                    {
-                        BookEntity originalBook = original.Books.FirstOrDefault(x => x.UniqueId == book.UniqueId);
-
-                        Assert.NotNull(originalBook);
-                        Assert.Equal(originalBook.Name, book.Name);
-                        Assert.Equal(originalBook.NumberOfPages, book.NumberOfPages);
-                    }
+                    AssertAuthor(original, author);
                 }
             }
 
             File.Delete(databaseName);
         }
 
-        public class TransitionDbContext : MigrationContext
+        private class MigrationTransitionDbContext : MigrationContext
         {
-            public TransitionDbContext(DbContextOptions options) : base(options)
+            public MigrationTransitionDbContext(DbContextOptions options) : base(options)
             {
             }
 
-            public TransitionDbContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null) 
+            public MigrationTransitionDbContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
                 : base(options, encryptionProvider)
             {
             }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
@@ -1,0 +1,97 @@
+﻿using Bogus;
+using Microsoft.EntityFrameworkCore.DataEncryption;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers.Obsolete;
+using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+    public class V1ToV2MigratorTest
+    {
+        private readonly IEnumerable<AuthorEntity> _authors;
+
+        public V1ToV2MigratorTest()
+        {
+            var faker = new Faker();
+            _authors = Enumerable.Range(0, faker.Random.Byte())
+                .Select(x => new AuthorEntity(faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Int(0, 90))
+                {
+                    Books = Enumerable.Range(0, 10)
+                                .Select(y => new BookEntity(faker.Lorem.Sentence(), faker.Random.Int(100, 500))
+                                {
+                                }).ToList()
+                }).ToList();
+        }
+
+        [Fact]
+        public void MigrateV1ToV2Test()
+        {
+            string databaseName = $"{Guid.NewGuid()}.db";
+            var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+
+            // Feed database with V1 encrypted data.
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<DatabaseContext>(new AesProviderV1(aesKeys.Key, aesKeys.IV));
+
+                context.Authors.AddRange(_authors);
+                context.SaveChanges();
+            }
+
+            // Process migration
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<TransitionDbContext>();
+                var migrator = new DataMigrator<TransitionDbContext>(context);
+
+                migrator.MigrateAesV1ToV2(new AesProvider(aesKeys.Key), aesKeys.Key, aesKeys.IV);
+            }
+
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                using var context = contextFactory.CreateContext<MigrationContext>(new AesProvider(aesKeys.Key));
+                IEnumerable<AuthorEntity> authors = context.Authors.Include(x => x.Books);
+
+                foreach (AuthorEntity author in authors)
+                {
+                    AuthorEntity original = _authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+
+                    Assert.NotNull(original);
+                    Assert.Equal(original.FirstName, author.FirstName);
+                    Assert.Equal(original.LastName, author.LastName);
+                    Assert.Equal(original.Age, author.Age);
+                    Assert.Equal(original.Books.Count, author.Books.Count);
+
+                    foreach (BookEntity book in author.Books)
+                    {
+                        BookEntity originalBook = original.Books.FirstOrDefault(x => x.UniqueId == book.UniqueId);
+
+                        Assert.NotNull(originalBook);
+                        Assert.Equal(originalBook.Name, book.Name);
+                        Assert.Equal(originalBook.NumberOfPages, book.NumberOfPages);
+                    }
+                }
+            }
+
+            File.Delete(databaseName);
+        }
+
+        public class TransitionDbContext : MigrationContext
+        {
+            public TransitionDbContext(DbContextOptions options) : base(options)
+            {
+            }
+
+            public TransitionDbContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null) 
+                : base(options, encryptionProvider)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a simple data migration mechanism that allows the following migration types:
* Original data to encrypted
* Encrypted data to original
* V1 to V2 migration

Before using the `DataMigrator`, please ensure you have a backup of you database. For all migration tools, a database backup should be done before executing any migration operation.

Covers issue #7 