### PR TITLE
Enahnced data type support

### DIFF
--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -7,10 +7,22 @@ steps:
     packageType: 'sdk'
     version: '5.0.x'
 
+# Build solution
 - script: |
     dotnet build EntityFrameworkCore.DataEncryption.sln --configuration Release
   displayName: 'Build'
 
+# Test solution
 - script: |
-    dotnet test EntityFrameworkCore.DataEncryption.sln --configuration Release
+    dotnet test EntityFrameworkCore.DataEncryption.sln --configuration Release /p:CollectCoverage=true /p:Exclude="[xunit*]*" /p:CoverletOutputFormat=opencover /p:CoverletOutput="../TestResults/TestResults.xml" /maxcpucount:1
   displayName: 'Test'
+
+# Upload coverage
+- script: |
+    bash <(curl -s https://codecov.io/bash) -f ./test/TestResults/TestResults.xml
+  displayName: 'Upload code coverage'
+
+# Publish code coverage results as artifacts
+- publish: $(System.DefaultWorkingDirectory)/test/TestResults
+  artifact: CoverageResults
+  displayName: 'Publish code coverage results'

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+[*.cs]
+indent_style = space
+indent_size = 4
+
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = methods, object_collection_array_initializers, control_blocks, types
+dotnet_sort_system_directives_first = true
+
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+csharp_prefer_braces = true:warning
+
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,sealed,async,override,abstract:suggestion
+
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion

--- a/EntityFrameworkCore.DataEncryption.sln
+++ b/EntityFrameworkCore.DataEncryption.sln
@@ -20,7 +20,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{3A8D80
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{64C3D7D1-67B8-4070-AE67-C71B761535CC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AesSample", "samples\AesSample\AesSample.csproj", "{8AA1E576-4016-4623-96C8-90330F05F9A8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AesSample", "samples\AesSample\AesSample.csproj", "{8AA1E576-4016-4623-96C8-90330F05F9A8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".azure", ".azure", "{073FEA06-67CF-47F8-8CE4-2B153A7D8443}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pipelines", "pipelines", "{68558245-F605-413F-A1D9-A4F60D489D68}"
+	ProjectSection(SolutionItems) = preProject
+		.azure\pipelines\azure-pipelines.yml = .azure\pipelines\azure-pipelines.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,6 +55,8 @@ Global
 		{D037F8D0-E606-4C5A-8669-DB6AAE7B056B} = {3EC10767-1816-46B2-A78E-9856071CCFDB}
 		{5E023B6A-0B47-4EC2-90B9-2DF998E58ADB} = {E4089551-AF4E-41B3-A6F8-2501A3BE0E0C}
 		{8AA1E576-4016-4623-96C8-90330F05F9A8} = {64C3D7D1-67B8-4070-AE67-C71B761535CC}
+		{073FEA06-67CF-47F8-8CE4-2B153A7D8443} = {3A8D800E-77BD-44EF-82DB-C672281ECAAA}
+		{68558245-F605-413F-A1D9-A4F60D489D68} = {073FEA06-67CF-47F8-8CE4-2B153A7D8443}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4997BAE9-29BF-4D79-AE5E-5605E7A0F049}

--- a/EntityFrameworkCore.DataEncryption.sln
+++ b/EntityFrameworkCore.DataEncryption.sln
@@ -28,6 +28,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pipelines", "pipelines", "{
 	ProjectSection(SolutionItems) = preProject
 		.azure\pipelines\azure-pipelines.yml = .azure\pipelines\azure-pipelines.yml
 	EndProjectSection
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5EE4E8BE-6B15-49DB-A4A8-D2CD63D5E90C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/AesSample/Program.cs
+++ b/samples/AesSample/Program.cs
@@ -2,38 +2,55 @@
 using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
 using System;
 using System.Linq;
+using System.Security;
 
 namespace AesSample
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var options = new DbContextOptionsBuilder<DatabaseContext>()
-                .UseInMemoryDatabase(databaseName: "MyInMemoryDatabase")
-                .Options;
+	static class Program
+	{
+		static void Main()
+		{
+			var options = new DbContextOptionsBuilder<DatabaseContext>()
+				.UseInMemoryDatabase(databaseName: "MyInMemoryDatabase")
+				.Options;
 
-            // AES key randomly generated at each run.
-            byte[] encryptionKey = AesProvider.GenerateKey(AesKeySize.AES256Bits).Key;
-            var encryptionProvider = new AesProvider(encryptionKey);
+			// AES key randomly generated at each run.
+			byte[] encryptionKey = AesProvider.GenerateKey(AesKeySize.AES256Bits).Key;
+			var encryptionProvider = new AesProvider(encryptionKey);
 
-            using var context = new DatabaseContext(options, encryptionProvider);
+			using var context = new DatabaseContext(options, encryptionProvider);
 
-            var user = new UserEntity
-            {
-                FirstName = "John",
-                LastName = "Doe",
-                Email = "john@doe.com"
-            };
+			var user = new UserEntity
+			{
+				FirstName = "John",
+				LastName = "Doe",
+				Email = "john@doe.com",
+				Password = BuildPassword(),
+			};
 
-            context.Users.Add(user);
-            context.SaveChanges();
+			context.Users.Add(user);
+			context.SaveChanges();
 
-            Console.WriteLine($"Users count: {context.Users.Count()}");
+			Console.WriteLine($"Users count: {context.Users.Count()}");
 
-            user = context.Users.FirstOrDefault();
+			user = context.Users.First();
 
-            Console.WriteLine($"User: {user.FirstName} {user.LastName} - {user.Email}");
-        }
-    }
+			Console.WriteLine($"User: {user.FirstName} {user.LastName} - {user.Email} ({user.Password.Length})");
+		}
+
+		static SecureString BuildPassword()
+		{
+			SecureString result = new();
+			result.AppendChar('L');
+			result.AppendChar('e');
+			result.AppendChar('t');
+			result.AppendChar('M');
+			result.AppendChar('e');
+			result.AppendChar('I');
+			result.AppendChar('n');
+			result.AppendChar('!');
+			result.MakeReadOnly();
+			return result;
+		}
+	}
 }

--- a/samples/AesSample/Program.cs
+++ b/samples/AesSample/Program.cs
@@ -6,51 +6,51 @@ using System.Security;
 
 namespace AesSample
 {
-	static class Program
-	{
-		static void Main()
-		{
-			var options = new DbContextOptionsBuilder<DatabaseContext>()
-				.UseInMemoryDatabase(databaseName: "MyInMemoryDatabase")
-				.Options;
+    static class Program
+    {
+        static void Main()
+        {
+            var options = new DbContextOptionsBuilder<DatabaseContext>()
+                .UseInMemoryDatabase(databaseName: "MyInMemoryDatabase")
+                .Options;
 
-			// AES key randomly generated at each run.
-			byte[] encryptionKey = AesProvider.GenerateKey(AesKeySize.AES256Bits).Key;
-			var encryptionProvider = new AesProvider(encryptionKey);
+            // AES key randomly generated at each run.
+            byte[] encryptionKey = AesProvider.GenerateKey(AesKeySize.AES256Bits).Key;
+            var encryptionProvider = new AesProvider(encryptionKey);
 
-			using var context = new DatabaseContext(options, encryptionProvider);
+            using var context = new DatabaseContext(options, encryptionProvider);
 
-			var user = new UserEntity
-			{
-				FirstName = "John",
-				LastName = "Doe",
-				Email = "john@doe.com",
-				Password = BuildPassword(),
-			};
+            var user = new UserEntity
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                Email = "john@doe.com",
+                Password = BuildPassword(),
+            };
 
-			context.Users.Add(user);
-			context.SaveChanges();
+            context.Users.Add(user);
+            context.SaveChanges();
 
-			Console.WriteLine($"Users count: {context.Users.Count()}");
+            Console.WriteLine($"Users count: {context.Users.Count()}");
 
-			user = context.Users.First();
+            user = context.Users.First();
 
-			Console.WriteLine($"User: {user.FirstName} {user.LastName} - {user.Email} ({user.Password.Length})");
-		}
+            Console.WriteLine($"User: {user.FirstName} {user.LastName} - {user.Email} ({user.Password.Length})");
+        }
 
-		static SecureString BuildPassword()
-		{
-			SecureString result = new();
-			result.AppendChar('L');
-			result.AppendChar('e');
-			result.AppendChar('t');
-			result.AppendChar('M');
-			result.AppendChar('e');
-			result.AppendChar('I');
-			result.AppendChar('n');
-			result.AppendChar('!');
-			result.MakeReadOnly();
-			return result;
-		}
-	}
+        static SecureString BuildPassword()
+        {
+            SecureString result = new();
+            result.AppendChar('L');
+            result.AppendChar('e');
+            result.AppendChar('t');
+            result.AppendChar('M');
+            result.AppendChar('e');
+            result.AppendChar('I');
+            result.AppendChar('n');
+            result.AppendChar('!');
+            result.MakeReadOnly();
+            return result;
+        }
+    }
 }

--- a/samples/AesSample/UserEntity.cs
+++ b/samples/AesSample/UserEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Security;
 
 namespace AesSample
 {
@@ -19,5 +20,7 @@ namespace AesSample
         [Required]
         [Encrypted]
         public string Email { get; set; }
+
+        public SecureString Password { get; set; }
     }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Attributes/EncryptedAttribute.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Attributes/EncryptedAttribute.cs
@@ -1,32 +1,32 @@
 ﻿namespace System.ComponentModel.DataAnnotations
 {
-	/// <summary>
-	/// Specifies that the data field value should be encrypted.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-	public sealed class EncryptedAttribute : Attribute
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="EncryptedAttribute"/> class.
-		/// </summary>
-		/// <param name="format">
-		/// The storage format.
-		/// </param>
-		public EncryptedAttribute(StorageFormat format)
-		{
-			Format = format;
-		}
+    /// <summary>
+    /// Specifies that the data field value should be encrypted.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class EncryptedAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EncryptedAttribute"/> class.
+        /// </summary>
+        /// <param name="format">
+        /// The storage format.
+        /// </param>
+        public EncryptedAttribute(StorageFormat format)
+        {
+            Format = format;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="EncryptedAttribute"/> class.
-		/// </summary>
-		public EncryptedAttribute() : this(StorageFormat.Default)
-		{
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EncryptedAttribute"/> class.
+        /// </summary>
+        public EncryptedAttribute() : this(StorageFormat.Default)
+        {
+        }
 
-		/// <summary>
-		/// Returns the storage format for the database value.
-		/// </summary>
-		public StorageFormat Format { get; }
-	}
+        /// <summary>
+        /// Returns the storage format for the database value.
+        /// </summary>
+        public StorageFormat Format { get; }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Attributes/EncryptedAttribute.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Attributes/EncryptedAttribute.cs
@@ -1,10 +1,32 @@
 ﻿namespace System.ComponentModel.DataAnnotations
 {
-    /// <summary>
-    /// Specifies that the data field value should be encrypted.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    public sealed class EncryptedAttribute : Attribute
-    {
-    }
+	/// <summary>
+	/// Specifies that the data field value should be encrypted.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+	public sealed class EncryptedAttribute : Attribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EncryptedAttribute"/> class.
+		/// </summary>
+		/// <param name="format">
+		/// The storage format.
+		/// </param>
+		public EncryptedAttribute(StorageFormat format)
+		{
+			Format = format;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EncryptedAttribute"/> class.
+		/// </summary>
+		public EncryptedAttribute() : this(StorageFormat.Default)
+		{
+		}
+
+		/// <summary>
+		/// Returns the storage format for the database value.
+		/// </summary>
+		public StorageFormat Format { get; }
+	}
 }

--- a/src/EntityFrameworkCore.DataEncryption/Attributes/StorageFormat.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Attributes/StorageFormat.cs
@@ -1,26 +1,26 @@
 ﻿namespace System.ComponentModel.DataAnnotations
 {
-	/// <summary>
-	/// Represents the storage format for an encrypted value.
-	/// </summary>
-	public enum StorageFormat
-	{
-		/// <summary>
-		/// The format is determined by the model data type.
-		/// </summary>
-		Default,
-		/// <summary>
-		/// The value is stored in binary.
-		/// </summary>
-		Binary,
-		/// <summary>
-		/// The value is stored in a Base64-encoded string.
-		/// </summary>
-		/// <remarks>
-		/// <b>NB:</b> If the source property is a <see cref="string"/>,
-		/// and no encryption provider is configured,
-		/// the string will not be modified.
-		/// </remarks>
-		Base64,
-	}
+    /// <summary>
+    /// Represents the storage format for an encrypted value.
+    /// </summary>
+    public enum StorageFormat
+    {
+        /// <summary>
+        /// The format is determined by the model data type.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// The value is stored in binary.
+        /// </summary>
+        Binary,
+        /// <summary>
+        /// The value is stored in a Base64-encoded string.
+        /// </summary>
+        /// <remarks>
+        /// <b>NB:</b> If the source property is a <see cref="string"/>,
+        /// and no encryption provider is configured,
+        /// the string will not be modified.
+        /// </remarks>
+        Base64,
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Attributes/StorageFormat.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Attributes/StorageFormat.cs
@@ -1,0 +1,26 @@
+﻿namespace System.ComponentModel.DataAnnotations
+{
+	/// <summary>
+	/// Represents the storage format for an encrypted value.
+	/// </summary>
+	public enum StorageFormat
+	{
+		/// <summary>
+		/// The format is determined by the model data type.
+		/// </summary>
+		Default,
+		/// <summary>
+		/// The value is stored in binary.
+		/// </summary>
+		Binary,
+		/// <summary>
+		/// The value is stored in a Base64-encoded string.
+		/// </summary>
+		/// <remarks>
+		/// <b>NB:</b> If the source property is a <see cref="string"/>,
+		/// and no encryption provider is configured,
+		/// the string will not be modified.
+		/// </remarks>
+		Base64,
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -1,38 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
-    <AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
-    <RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
-    <Version>2.0.0</Version>
-    <Authors>Filipe GOMES PEIXOTO</Authors>
-    <PackageId>EntityFrameworkCore.DataEncryption</PackageId>
-    <PackageProjectUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageTags>entity-framework-core, extensions, dotnet-core, dotnet, encryption, fluent-api</PackageTags>
-    <LangVersion>8.0</LangVersion>
-    <PackageIcon>icon.png</PackageIcon>
-    <Copyright>Filipe GOMES PEIXOTO © 2019 - 2020</Copyright>
-    <Description>A plugin for Microsoft.EntityFrameworkCore to add support of encrypted fields using built-in or custom encryption providers.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>- Remove initializationVector parameter from `AesProvider` constructor.
-- Apply unique IV for each row.</PackageReleaseNotes>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<LangVersion>9.0</LangVersion>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
+		<RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
+		<Version>3.0.0</Version>
+		<Authors>Filipe GOMES PEIXOTO</Authors>
+		<PackageId>EntityFrameworkCore.DataEncryption</PackageId>
+		<PackageProjectUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<PackageTags>entity-framework-core, extensions, dotnet-core, dotnet, encryption, fluent-api</PackageTags>
+		<PackageIcon>icon.png</PackageIcon>
+		<Copyright>Filipe GOMES PEIXOTO © 2019 - 2020</Copyright>
+		<Description>A plugin for Microsoft.EntityFrameworkCore to add support of encrypted fields using built-in or custom encryption providers.</Description>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReleaseNotes>
+			- Add support for storing data as binary or Base64
+			- Add support for SecureString and binary model properties
+		</PackageReleaseNotes>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="Resources/icon.png" Pack="true" Visible="true" PackagePath="" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+		<None Include="Resources/icon.png" Pack="true" Visible="true" PackagePath="" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Microsoft.EntityFrameworkCore.Encryption.Test</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj.DotSettings
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp90</s:String></wpf:ResourceDictionary>

--- a/src/EntityFrameworkCore.DataEncryption/IEncryptionProvider.cs
+++ b/src/EntityFrameworkCore.DataEncryption/IEncryptionProvider.cs
@@ -1,22 +1,67 @@
-﻿namespace Microsoft.EntityFrameworkCore.DataEncryption
-{
-    /// <summary>
-    /// Provides a mechanism for implementing a custom encryption provider.
-    /// </summary>
-    public interface IEncryptionProvider
-    {
-        /// <summary>
-        /// Encrypts a string.
-        /// </summary>
-        /// <param name="dataToEncrypt">Input data as a string to encrypt.</param>
-        /// <returns>Encrypted data as a string.</returns>
-        string Encrypt(string dataToEncrypt);
+﻿using System;
+using System.IO;
 
-        /// <summary>
-        /// Decrypts a string.
-        /// </summary>
-        /// <param name="dataToDecrypt">Encrypted data as a string to decrypt.</param>
-        /// <returns>Decrypted data as a string.</returns>
-        string Decrypt(string dataToDecrypt);
-    }
+namespace Microsoft.EntityFrameworkCore.DataEncryption
+{
+	/// <summary>
+	/// Provides a mechanism for implementing a custom encryption provider.
+	/// </summary>
+	public interface IEncryptionProvider
+	{
+		/// <summary>
+		/// Encrypts a value.
+		/// </summary>
+		/// <typeparam name="TStore">
+		/// The type of data stored in the database.
+		/// </typeparam>
+		/// <typeparam name="TModel">
+		/// The type of value stored in the model.
+		/// </typeparam>
+		/// <param name="dataToEncrypt">
+		/// Input data to encrypt.
+		/// </param>
+		/// <param name="converter">
+		/// Function which converts the model value to a byte array.
+		/// </param>
+		/// <param name="encoder">
+		/// Function which encodes the value for storing the the database.
+		/// </param>
+		/// <returns>
+		/// Encrypted data.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="converter"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
+		/// </exception>
+		TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder);
+
+		/// <summary>
+		/// Decrypts a value.
+		/// </summary>
+		/// <typeparam name="TStore">
+		/// The type of data stored in the database.
+		/// </typeparam>
+		/// <typeparam name="TModel">
+		/// The type of value stored in the model.
+		/// </typeparam>
+		/// <param name="dataToDecrypt">
+		/// Encrypted data to decrypt.
+		/// </param>
+		/// <param name="decoder">
+		/// Function which converts the stored data to a byte array.
+		/// </param>
+		/// <param name="converter">
+		/// Function which converts the decrypted <see cref="Stream"/> to the return value.
+		/// </param>
+		/// <returns>
+		/// Decrypted data.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="converter"/> is <see langword="null"/>.</para>
+		/// </exception>
+		TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter);
+	}
 }

--- a/src/EntityFrameworkCore.DataEncryption/IEncryptionProvider.cs
+++ b/src/EntityFrameworkCore.DataEncryption/IEncryptionProvider.cs
@@ -3,65 +3,65 @@ using System.IO;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption
 {
-	/// <summary>
-	/// Provides a mechanism for implementing a custom encryption provider.
-	/// </summary>
-	public interface IEncryptionProvider
-	{
-		/// <summary>
-		/// Encrypts a value.
-		/// </summary>
-		/// <typeparam name="TStore">
-		/// The type of data stored in the database.
-		/// </typeparam>
-		/// <typeparam name="TModel">
-		/// The type of value stored in the model.
-		/// </typeparam>
-		/// <param name="dataToEncrypt">
-		/// Input data to encrypt.
-		/// </param>
-		/// <param name="converter">
-		/// Function which converts the model value to a byte array.
-		/// </param>
-		/// <param name="encoder">
-		/// Function which encodes the value for storing the the database.
-		/// </param>
-		/// <returns>
-		/// Encrypted data.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="converter"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
-		/// </exception>
-		TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder);
+    /// <summary>
+    /// Provides a mechanism for implementing a custom encryption provider.
+    /// </summary>
+    public interface IEncryptionProvider
+    {
+        /// <summary>
+        /// Encrypts a value.
+        /// </summary>
+        /// <typeparam name="TStore">
+        /// The type of data stored in the database.
+        /// </typeparam>
+        /// <typeparam name="TModel">
+        /// The type of value stored in the model.
+        /// </typeparam>
+        /// <param name="dataToEncrypt">
+        /// Input data to encrypt.
+        /// </param>
+        /// <param name="converter">
+        /// Function which converts the model value to a byte array.
+        /// </param>
+        /// <param name="encoder">
+        /// Function which encodes the value for storing the the database.
+        /// </param>
+        /// <returns>
+        /// Encrypted data.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="converter"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
+        /// </exception>
+        TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder);
 
-		/// <summary>
-		/// Decrypts a value.
-		/// </summary>
-		/// <typeparam name="TStore">
-		/// The type of data stored in the database.
-		/// </typeparam>
-		/// <typeparam name="TModel">
-		/// The type of value stored in the model.
-		/// </typeparam>
-		/// <param name="dataToDecrypt">
-		/// Encrypted data to decrypt.
-		/// </param>
-		/// <param name="decoder">
-		/// Function which converts the stored data to a byte array.
-		/// </param>
-		/// <param name="converter">
-		/// Function which converts the decrypted <see cref="Stream"/> to the return value.
-		/// </param>
-		/// <returns>
-		/// Decrypted data.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="converter"/> is <see langword="null"/>.</para>
-		/// </exception>
-		TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter);
-	}
+        /// <summary>
+        /// Decrypts a value.
+        /// </summary>
+        /// <typeparam name="TStore">
+        /// The type of data stored in the database.
+        /// </typeparam>
+        /// <typeparam name="TModel">
+        /// The type of value stored in the model.
+        /// </typeparam>
+        /// <param name="dataToDecrypt">
+        /// Encrypted data to decrypt.
+        /// </param>
+        /// <param name="decoder">
+        /// Function which converts the stored data to a byte array.
+        /// </param>
+        /// <param name="converter">
+        /// Function which converts the decrypted <see cref="Stream"/> to the return value.
+        /// </param>
+        /// <returns>
+        /// Decrypted data.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="converter"/> is <see langword="null"/>.</para>
+        /// </exception>
+        TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter);
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder.cs
@@ -6,378 +6,419 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
 {
-	/// <summary>
-	/// Utilities for building value converters.
-	/// </summary>
-	public static class ConverterBuilder
-	{
-		#region Interfaces
+    /// <summary>
+    /// Utilities for building value converters.
+    /// </summary>
+    public static class ConverterBuilder
+    {
+        #region Interfaces
 
-		/// <summary>
-		/// Interface for a builder class which has the model type specified.
-		/// </summary>
-		/// <typeparam name="TModelType">
-		/// The model type.
-		/// </typeparam>
-		// ReSharper disable once UnusedTypeParameter
-		public interface INeedStoreType<TModelType> { }
+        /// <summary>
+        /// Interface for a builder class which has the model type specified.
+        /// </summary>
+        /// <typeparam name="TModelType">
+        /// The model type.
+        /// </typeparam>
+        // ReSharper disable once UnusedTypeParameter
+        public interface INeedStoreType<TModelType> { }
 
-		/// <summary>
-		/// Interface for a builder class with both the model and store types specified.
-		/// </summary>
-		/// <typeparam name="TModelType">
-		/// The model type.
-		/// </typeparam>
-		/// <typeparam name="TStoreType">
-		/// The store type.
-		/// </typeparam>
-		public interface IBuilder<TModelType, TStoreType>
-		{
-			/// <summary>
-			/// Builds the value converter.
-			/// </summary>
-			/// <param name="mappingHints">
-			/// The mapping hints to use, if any.
-			/// </param>
-			/// <returns>
-			/// The <see cref="ValueConverter{TModel,TProvider}"/>.
-			/// </returns>
-			ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null);
-		}
+        /// <summary>
+        /// Interface for a builder class with both the model and store types specified.
+        /// </summary>
+        /// <typeparam name="TModelType">
+        /// The model type.
+        /// </typeparam>
+        /// <typeparam name="TStoreType">
+        /// The store type.
+        /// </typeparam>
+        public interface IBuilder<TModelType, TStoreType>
+        {
+            /// <summary>
+            /// Builds the value converter.
+            /// </summary>
+            /// <param name="mappingHints">
+            /// The mapping hints to use, if any.
+            /// </param>
+            /// <returns>
+            /// The <see cref="ValueConverter{TModel,TProvider}"/>.
+            /// </returns>
+            ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null);
+        }
 
-		#endregion
+        #endregion
 
-		#region Encrypting
+        #region Encrypting
 
-		private sealed class NeedStoreType<TModelType> : INeedStoreType<TModelType>
-		{
-			public NeedStoreType(IEncryptionProvider encryptionProvider, Func<TModelType, byte[]> decoder, Func<Stream, TModelType> encoder)
-			{
-				EncryptionProvider = encryptionProvider ?? throw new ArgumentNullException(nameof(encryptionProvider));
-				Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
-				Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
-			}
+        private sealed class NeedStoreType<TModelType> : INeedStoreType<TModelType>
+        {
+            public NeedStoreType(IEncryptionProvider encryptionProvider, Func<TModelType, byte[]> decoder, Func<Stream, TModelType> encoder)
+            {
+                EncryptionProvider = encryptionProvider ?? throw new ArgumentNullException(nameof(encryptionProvider));
+                Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+                Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+            }
 
-			private IEncryptionProvider EncryptionProvider { get; }
-			private Func<TModelType, byte[]> Decoder { get; }
-			private Func<Stream, TModelType> Encoder { get; }
+            private IEncryptionProvider EncryptionProvider { get; }
+            private Func<TModelType, byte[]> Decoder { get; }
+            private Func<Stream, TModelType> Encoder { get; }
 
-			public void Deconstruct(out IEncryptionProvider encryptionProvider, out Func<TModelType, byte[]> decoder, out Func<Stream, TModelType> encoder)
-			{
-				encryptionProvider = EncryptionProvider;
-				decoder = Decoder;
-				encoder = Encoder;
-			}
-		}
+            public void Deconstruct(out IEncryptionProvider encryptionProvider, out Func<TModelType, byte[]> decoder, out Func<Stream, TModelType> encoder)
+            {
+                encryptionProvider = EncryptionProvider;
+                decoder = Decoder;
+                encoder = Encoder;
+            }
+        }
 
-		private sealed class EncryptionBuilder<TModelType, TStoreType> : IBuilder<TModelType, TStoreType>
-		{
-			public EncryptionBuilder(NeedStoreType<TModelType> modelType, Func<TStoreType, byte[]> decoder, Func<Stream, TStoreType> encoder)
-			{
-				ModelType = modelType ?? throw new ArgumentNullException(nameof(modelType));
-				Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
-				Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
-			}
+        private sealed class EncryptionBuilder<TModelType, TStoreType> : IBuilder<TModelType, TStoreType>
+        {
+            public EncryptionBuilder(NeedStoreType<TModelType> modelType, Func<TStoreType, byte[]> decoder, Func<Stream, TStoreType> encoder)
+            {
+                ModelType = modelType ?? throw new ArgumentNullException(nameof(modelType));
+                Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+                Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+            }
 
-			private NeedStoreType<TModelType> ModelType { get; }
-			private Func<TStoreType, byte[]> Decoder { get; }
-			private Func<Stream, TStoreType> Encoder { get; }
+            private NeedStoreType<TModelType> ModelType { get; }
+            private Func<TStoreType, byte[]> Decoder { get; }
+            private Func<Stream, TStoreType> Encoder { get; }
 
-			/// <inheritdoc />
-			public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
-			{
-				var (encryptionProvider, modelDecoder, modelEncoder) = ModelType;
-				var storeDecoder = Decoder;
-				var storeEncoder = Encoder;
+            /// <inheritdoc />
+            public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
+            {
+                var (encryptionProvider, modelDecoder, modelEncoder) = ModelType;
+                var storeDecoder = Decoder;
+                var storeEncoder = Encoder;
 
-				return new EncryptionConverter<TModelType, TStoreType>(
-					encryptionProvider,
-					m => encryptionProvider.Encrypt(m, modelDecoder, storeEncoder),
-					s => encryptionProvider.Decrypt(s, storeDecoder, modelEncoder),
-					mappingHints);
-			}
-		}
+                return new EncryptionConverter<TModelType, TStoreType>(
+                    encryptionProvider,
+                    m => encryptionProvider.Encrypt(m, modelDecoder, storeEncoder),
+                    s => encryptionProvider.Decrypt(s, storeDecoder, modelEncoder),
+                    mappingHints);
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Non-encrypting
+        #region Non-encrypting
 
-		private sealed class ByteConverter<T> : INeedStoreType<T>
-		{
-			public ByteConverter(Func<T, byte[]> decoder, Func<byte[], T> encoder)
-			{
-				Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
-				Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
-			}
+        private sealed class ByteConverter<T> : INeedStoreType<T>
+        {
+            public ByteConverter(Func<T, byte[]> decoder, Func<byte[], T> encoder)
+            {
+                Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+                Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+            }
 
-			private Func<T, byte[]> Decoder { get; }
-			private Func<byte[], T> Encoder { get; }
+            private Func<T, byte[]> Decoder { get; }
+            private Func<byte[], T> Encoder { get; }
 
-			public void Deconstruct(out Func<T, byte[]> decoder, out Func<byte[], T> encoder)
-			{
-				decoder = Decoder;
-				encoder = Encoder;
-			}
-		}
+            public void Deconstruct(out Func<T, byte[]> decoder, out Func<byte[], T> encoder)
+            {
+                decoder = Decoder;
+                encoder = Encoder;
+            }
+        }
 
-		private static class ByteConverter
-		{
-			public static ByteConverter<byte[]> Identity { get; } = new(b => b, b => b);
-			public static ByteConverter<string> Base64String { get; } = new(Convert.FromBase64String, Convert.ToBase64String);
-			public static ByteConverter<string> Utf8String { get; } = new(Encoding.UTF8.GetBytes, Encoding.UTF8.GetString);
-			public static ByteConverter<SecureString> Utf8SecureString { get; } = new(Encoding.UTF8.GetBytes, Encoding.UTF8.GetSecureString);
+        private static class ByteConverter
+        {
+            public static ByteConverter<byte[]> Identity { get; } = new(b => b, b => b);
+            public static ByteConverter<string> Base64String { get; } = new(Convert.FromBase64String, Convert.ToBase64String);
+            public static ByteConverter<string> Utf8String { get; } = new(Encoding.UTF8.GetBytes, Encoding.UTF8.GetString);
+            public static ByteConverter<SecureString> Utf8SecureString { get; } = new(Encoding.UTF8.GetBytes, Encoding.UTF8.GetSecureString);
 
-			public static Stream WrapBytes(byte[] bytes) => new MemoryStream(bytes);
-		}
+            public static Stream WrapBytes(byte[] bytes) => new MemoryStream(bytes);
+        }
 
-		private sealed class NonEncryptionBuilder<TModelType, TStoreType> : IBuilder<TModelType, TStoreType>
-		{
-			public NonEncryptionBuilder(ByteConverter<TModelType> modelConverter, ByteConverter<TStoreType> storeConverter)
-			{
-				ModelConverter = modelConverter ?? throw new ArgumentNullException(nameof(modelConverter));
-				StoreConverter = storeConverter ?? throw new ArgumentNullException(nameof(storeConverter));
-			}
+        private sealed class NonEncryptionBuilder<TModelType, TStoreType> : IBuilder<TModelType, TStoreType>
+        {
+            public NonEncryptionBuilder(ByteConverter<TModelType> modelConverter, ByteConverter<TStoreType> storeConverter)
+            {
+                ModelConverter = modelConverter ?? throw new ArgumentNullException(nameof(modelConverter));
+                StoreConverter = storeConverter ?? throw new ArgumentNullException(nameof(storeConverter));
+            }
 
-			private ByteConverter<TModelType> ModelConverter { get; }
-			private ByteConverter<TStoreType> StoreConverter { get; }
+            private ByteConverter<TModelType> ModelConverter { get; }
+            private ByteConverter<TStoreType> StoreConverter { get; }
 
-			/// <inheritdoc />
-			public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
-			{
-				var (modelDecoder, modelEncoder) = ModelConverter;
-				var (storeDecoder, storeEncoder) = StoreConverter;
-				return new ValueConverter<TModelType, TStoreType>(m => storeEncoder(modelDecoder(m)), s => modelEncoder(storeDecoder(s)), mappingHints);
-			}
-		}
+            /// <inheritdoc />
+            public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
+            {
+                var (modelDecoder, modelEncoder) = ModelConverter;
+                var (storeDecoder, storeEncoder) = StoreConverter;
+                return new ValueConverter<TModelType, TStoreType>(m => storeEncoder(modelDecoder(m)), s => modelEncoder(storeDecoder(s)), mappingHints);
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Standard Converters
+        #region Standard Converters
 
-		internal static byte[] StreamToBytes(Stream stream)
-		{
-			if (stream is MemoryStream ms) return ms.ToArray();
+        internal static byte[] StreamToBytes(Stream stream)
+        {
+            if (stream is MemoryStream ms)
+            {
+                return ms.ToArray();
+            }
 
-			using var output = new MemoryStream();
-			stream.CopyTo(output);
-			return output.ToArray();
-		}
+            using var output = new MemoryStream();
+            stream.CopyTo(output);
+            return output.ToArray();
+        }
 
-		internal static string StreamToBase64String(Stream stream) => Convert.ToBase64String(StreamToBytes(stream));
+        internal static string StreamToBase64String(Stream stream) => Convert.ToBase64String(StreamToBytes(stream));
 
-		internal static string StreamToString(Stream stream)
-		{
-			using var reader = new StreamReader(stream, Encoding.UTF8);
-			return reader.ReadToEnd().Trim('\0');
-		}
+        internal static string StreamToString(Stream stream)
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd().Trim('\0');
+        }
 
-		internal static SecureString StreamToSecureString(Stream stream)
-		{
-			using var reader = new StreamReader(stream, Encoding.UTF8);
+        internal static SecureString StreamToSecureString(Stream stream)
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
 
-			var result = new SecureString();
-			var buffer = new char[100];
-			while (!reader.EndOfStream)
-			{
-				var charsRead = reader.Read(buffer, 0, buffer.Length);
-				if (charsRead != 0)
-				{
-					for (int index = 0; index < charsRead; index++)
-					{
-						char c = buffer[index];
-						if (c != '\0') result.AppendChar(c);
-					}
-				}
-			}
+            var result = new SecureString();
+            var buffer = new char[100];
+            while (!reader.EndOfStream)
+            {
+                var charsRead = reader.Read(buffer, 0, buffer.Length);
+                if (charsRead != 0)
+                {
+                    for (int index = 0; index < charsRead; index++)
+                    {
+                        char c = buffer[index];
+                        if (c != '\0')
+                        {
+                            result.AppendChar(c);
+                        }
+                    }
+                }
+            }
 
-			return result;
-		}
+            return result;
+        }
 
-		#endregion
+        #endregion
 
-		#region Builders
+        #region Builders
 
-		/// <summary>
-		/// Builds a converter for a property with a custom model type.
-		/// </summary>
-		/// <typeparam name="TModelType">
-		/// The model type.
-		/// </typeparam>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/>, if any.
-		/// </param>
-		/// <param name="decoder">
-		/// The function used to decode the model type to a byte array.
-		/// </param>
-		/// <param name="encoder">
-		/// The function used to encode a byte array to the model type.
-		/// </param>
-		/// <returns>
-		/// An <see cref="INeedStoreType{TModelType}"/> instance.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
-		/// </exception>
-		public static INeedStoreType<TModelType> From<TModelType>(
-			this IEncryptionProvider encryptionProvider,
-			Func<TModelType, byte[]> decoder,
-			Func<Stream, TModelType> encoder)
-		{
-			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
-			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
-			if (encryptionProvider is not null) return new NeedStoreType<TModelType>(encryptionProvider, decoder, encoder);
-			return new ByteConverter<TModelType>(decoder, b => encoder(ByteConverter.WrapBytes(b)));
-		}
+        /// <summary>
+        /// Builds a converter for a property with a custom model type.
+        /// </summary>
+        /// <typeparam name="TModelType">
+        /// The model type.
+        /// </typeparam>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/>, if any.
+        /// </param>
+        /// <param name="decoder">
+        /// The function used to decode the model type to a byte array.
+        /// </param>
+        /// <param name="encoder">
+        /// The function used to encode a byte array to the model type.
+        /// </param>
+        /// <returns>
+        /// An <see cref="INeedStoreType{TModelType}"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
+        /// </exception>
+        public static INeedStoreType<TModelType> From<TModelType>(
+            this IEncryptionProvider encryptionProvider,
+            Func<TModelType, byte[]> decoder,
+            Func<Stream, TModelType> encoder)
+        {
+            if (decoder is null)
+            {
+                throw new ArgumentNullException(nameof(decoder));
+            }
 
-		/// <summary>
-		/// Builds a converter for a binary property.
-		/// </summary>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/>, if any.
-		/// </param>
-		/// <returns>
-		/// An <see cref="INeedStoreType{TModelType}"/> instance.
-		/// </returns>
-		public static INeedStoreType<byte[]> FromBinary(this IEncryptionProvider encryptionProvider)
-		{
-			if (encryptionProvider is null) return ByteConverter.Identity;
-			return new NeedStoreType<byte[]>(encryptionProvider, b => b, StreamToBytes);
-		}
+            if (encoder is null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
 
-		/// <summary>
-		/// Builds a converter for a string property.
-		/// </summary>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/>, if any.
-		/// </param>
-		/// <returns>
-		/// An <see cref="INeedStoreType{TModelType}"/> instance.
-		/// </returns>
-		public static INeedStoreType<string> FromString(this IEncryptionProvider encryptionProvider)
-		{
-			if (encryptionProvider is null) return ByteConverter.Utf8String;
-			return new NeedStoreType<string>(encryptionProvider, Encoding.UTF8.GetBytes, StreamToString);
-		}
+            if (encryptionProvider is not null)
+            {
+                return new NeedStoreType<TModelType>(encryptionProvider, decoder, encoder);
+            }
 
-		/// <summary>
-		/// Builds a converter for a <see cref="SecureString"/> property.
-		/// </summary>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/>, if any.
-		/// </param>
-		/// <returns>
-		/// An <see cref="INeedStoreType{TModelType}"/> instance.
-		/// </returns>
-		public static INeedStoreType<SecureString> FromSecureString(this IEncryptionProvider encryptionProvider)
-		{
-			if (encryptionProvider is null) return ByteConverter.Utf8SecureString;
-			return new NeedStoreType<SecureString>(encryptionProvider, Encoding.UTF8.GetBytes, StreamToSecureString);
-		}
+            return new ByteConverter<TModelType>(decoder, b => encoder(ByteConverter.WrapBytes(b)));
+        }
 
-		/// <summary>
-		/// Specifies that the property should be stored in the database using a custom format.
-		/// </summary>
-		/// <typeparam name="TModelType">
-		/// The model type.
-		/// </typeparam>
-		/// <typeparam name="TStoreType">
-		/// The store type.
-		/// </typeparam>
-		/// <param name="modelType">
-		/// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
-		/// </param>
-		/// <param name="decoder">
-		/// The function used to decode the store type into a byte array.
-		/// </param>
-		/// <param name="encoder">
-		/// The function used to encode a byte array into the store type.
-		/// </param>
-		/// <returns>
-		/// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="modelType"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="modelType"/> is not a supported type.
-		/// </exception>
-		public static IBuilder<TModelType, TStoreType> To<TModelType, TStoreType>(
-			INeedStoreType<TModelType> modelType,
-			Func<TStoreType, byte[]> decoder,
-			Func<Stream, TStoreType> encoder)
-		{
-			if (modelType is null) throw new ArgumentNullException(nameof(modelType));
-			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
-			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
+        /// <summary>
+        /// Builds a converter for a binary property.
+        /// </summary>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/>, if any.
+        /// </param>
+        /// <returns>
+        /// An <see cref="INeedStoreType{TModelType}"/> instance.
+        /// </returns>
+        public static INeedStoreType<byte[]> FromBinary(this IEncryptionProvider encryptionProvider)
+        {
+            if (encryptionProvider is null)
+            {
+                return ByteConverter.Identity;
+            }
 
-			return modelType switch
-			{
-				ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, TStoreType>(converter, new ByteConverter<TStoreType>(decoder, b => encoder(ByteConverter.WrapBytes(b)))),
-				NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, TStoreType>(converter, decoder, encoder),
-				_ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
-			};
-		}
+            return new NeedStoreType<byte[]>(encryptionProvider, b => b, StreamToBytes);
+        }
 
-		/// <summary>
-		/// Specifies that the property should be stored in the database in binary.
-		/// </summary>
-		/// <typeparam name="TModelType">
-		/// The model type.
-		/// </typeparam>
-		/// <param name="modelType">
-		/// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
-		/// </param>
-		/// <returns>
-		/// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="modelType"/> is <see langword="null"/>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="modelType"/> is not a supported type.
-		/// </exception>
-		public static IBuilder<TModelType, byte[]> ToBinary<TModelType>(this INeedStoreType<TModelType> modelType) => modelType switch
-		{
-			// ReSharper disable once HeuristicUnreachableCode
-			null => throw new ArgumentNullException(nameof(modelType)),
-			ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, byte[]>(converter, ByteConverter.Identity),
-			NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, byte[]>(converter, b => b, StreamToBytes),
-			_ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
-		};
+        /// <summary>
+        /// Builds a converter for a string property.
+        /// </summary>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/>, if any.
+        /// </param>
+        /// <returns>
+        /// An <see cref="INeedStoreType{TModelType}"/> instance.
+        /// </returns>
+        public static INeedStoreType<string> FromString(this IEncryptionProvider encryptionProvider)
+        {
+            if (encryptionProvider is null)
+            {
+                return ByteConverter.Utf8String;
+            }
 
-		/// <summary>
-		/// Specifies that the property should be stored in the database in a Base64-encoded string.
-		/// </summary>
-		/// <typeparam name="TModelType">
-		/// The model type.
-		/// </typeparam>
-		/// <param name="modelType">
-		/// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
-		/// </param>
-		/// <returns>
-		/// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="modelType"/> is <see langword="null"/>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="modelType"/> is not a supported type.
-		/// </exception>
-		public static IBuilder<TModelType, string> ToBase64<TModelType>(this INeedStoreType<TModelType> modelType) => modelType switch
-		{
-			// ReSharper disable once HeuristicUnreachableCode
-			null => throw new ArgumentNullException(nameof(modelType)),
-			ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, string>(converter, ByteConverter.Base64String),
-			NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, string>(converter, Convert.FromBase64String, StreamToBase64String),
-			_ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
-		};
+            return new NeedStoreType<string>(encryptionProvider, Encoding.UTF8.GetBytes, StreamToString);
+        }
 
-		#endregion
-	}
+        /// <summary>
+        /// Builds a converter for a <see cref="SecureString"/> property.
+        /// </summary>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/>, if any.
+        /// </param>
+        /// <returns>
+        /// An <see cref="INeedStoreType{TModelType}"/> instance.
+        /// </returns>
+        public static INeedStoreType<SecureString> FromSecureString(this IEncryptionProvider encryptionProvider)
+        {
+            if (encryptionProvider is null)
+            {
+                return ByteConverter.Utf8SecureString;
+            }
+
+            return new NeedStoreType<SecureString>(encryptionProvider, Encoding.UTF8.GetBytes, StreamToSecureString);
+        }
+
+        /// <summary>
+        /// Specifies that the property should be stored in the database using a custom format.
+        /// </summary>
+        /// <typeparam name="TModelType">
+        /// The model type.
+        /// </typeparam>
+        /// <typeparam name="TStoreType">
+        /// The store type.
+        /// </typeparam>
+        /// <param name="modelType">
+        /// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
+        /// </param>
+        /// <param name="decoder">
+        /// The function used to decode the store type into a byte array.
+        /// </param>
+        /// <param name="encoder">
+        /// The function used to encode a byte array into the store type.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="modelType"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="modelType"/> is not a supported type.
+        /// </exception>
+        public static IBuilder<TModelType, TStoreType> To<TModelType, TStoreType>(
+            INeedStoreType<TModelType> modelType,
+            Func<TStoreType, byte[]> decoder,
+            Func<Stream, TStoreType> encoder)
+        {
+            if (modelType is null)
+            {
+                throw new ArgumentNullException(nameof(modelType));
+            }
+
+            if (decoder is null)
+            {
+                throw new ArgumentNullException(nameof(decoder));
+            }
+
+            if (encoder is null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
+
+            return modelType switch
+            {
+                ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, TStoreType>(converter, new ByteConverter<TStoreType>(decoder, b => encoder(ByteConverter.WrapBytes(b)))),
+                NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, TStoreType>(converter, decoder, encoder),
+                _ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
+            };
+        }
+
+        /// <summary>
+        /// Specifies that the property should be stored in the database in binary.
+        /// </summary>
+        /// <typeparam name="TModelType">
+        /// The model type.
+        /// </typeparam>
+        /// <param name="modelType">
+        /// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="modelType"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="modelType"/> is not a supported type.
+        /// </exception>
+        public static IBuilder<TModelType, byte[]> ToBinary<TModelType>(this INeedStoreType<TModelType> modelType) => modelType switch
+        {
+            // ReSharper disable once HeuristicUnreachableCode
+            null => throw new ArgumentNullException(nameof(modelType)),
+            ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, byte[]>(converter, ByteConverter.Identity),
+            NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, byte[]>(converter, b => b, StreamToBytes),
+            _ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
+        };
+
+        /// <summary>
+        /// Specifies that the property should be stored in the database in a Base64-encoded string.
+        /// </summary>
+        /// <typeparam name="TModelType">
+        /// The model type.
+        /// </typeparam>
+        /// <param name="modelType">
+        /// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="modelType"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="modelType"/> is not a supported type.
+        /// </exception>
+        public static IBuilder<TModelType, string> ToBase64<TModelType>(this INeedStoreType<TModelType> modelType) => modelType switch
+        {
+            // ReSharper disable once HeuristicUnreachableCode
+            null => throw new ArgumentNullException(nameof(modelType)),
+            ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, string>(converter, ByteConverter.Base64String),
+            NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, string>(converter, Convert.FromBase64String, StreamToBase64String),
+            _ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
+        };
+
+        #endregion
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder.cs
@@ -1,0 +1,383 @@
+﻿using System;
+using System.IO;
+using System.Security;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
+{
+	/// <summary>
+	/// Utilities for building value converters.
+	/// </summary>
+	public static class ConverterBuilder
+	{
+		#region Interfaces
+
+		/// <summary>
+		/// Interface for a builder class which has the model type specified.
+		/// </summary>
+		/// <typeparam name="TModelType">
+		/// The model type.
+		/// </typeparam>
+		// ReSharper disable once UnusedTypeParameter
+		public interface INeedStoreType<TModelType> { }
+
+		/// <summary>
+		/// Interface for a builder class with both the model and store types specified.
+		/// </summary>
+		/// <typeparam name="TModelType">
+		/// The model type.
+		/// </typeparam>
+		/// <typeparam name="TStoreType">
+		/// The store type.
+		/// </typeparam>
+		public interface IBuilder<TModelType, TStoreType>
+		{
+			/// <summary>
+			/// Builds the value converter.
+			/// </summary>
+			/// <param name="mappingHints">
+			/// The mapping hints to use, if any.
+			/// </param>
+			/// <returns>
+			/// The <see cref="ValueConverter{TModel,TProvider}"/>.
+			/// </returns>
+			ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null);
+		}
+
+		#endregion
+
+		#region Encrypting
+
+		private sealed class NeedStoreType<TModelType> : INeedStoreType<TModelType>
+		{
+			public NeedStoreType(IEncryptionProvider encryptionProvider, Func<TModelType, byte[]> decoder, Func<Stream, TModelType> encoder)
+			{
+				EncryptionProvider = encryptionProvider ?? throw new ArgumentNullException(nameof(encryptionProvider));
+				Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+				Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+			}
+
+			private IEncryptionProvider EncryptionProvider { get; }
+			private Func<TModelType, byte[]> Decoder { get; }
+			private Func<Stream, TModelType> Encoder { get; }
+
+			public void Deconstruct(out IEncryptionProvider encryptionProvider, out Func<TModelType, byte[]> decoder, out Func<Stream, TModelType> encoder)
+			{
+				encryptionProvider = EncryptionProvider;
+				decoder = Decoder;
+				encoder = Encoder;
+			}
+		}
+
+		private sealed class EncryptionBuilder<TModelType, TStoreType> : IBuilder<TModelType, TStoreType>
+		{
+			public EncryptionBuilder(NeedStoreType<TModelType> modelType, Func<TStoreType, byte[]> decoder, Func<Stream, TStoreType> encoder)
+			{
+				ModelType = modelType ?? throw new ArgumentNullException(nameof(modelType));
+				Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+				Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+			}
+
+			private NeedStoreType<TModelType> ModelType { get; }
+			private Func<TStoreType, byte[]> Decoder { get; }
+			private Func<Stream, TStoreType> Encoder { get; }
+
+			/// <inheritdoc />
+			public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
+			{
+				var (encryptionProvider, modelDecoder, modelEncoder) = ModelType;
+				var storeDecoder = Decoder;
+				var storeEncoder = Encoder;
+
+				return new EncryptionConverter<TModelType, TStoreType>(
+					encryptionProvider,
+					m => encryptionProvider.Encrypt(m, modelDecoder, storeEncoder),
+					s => encryptionProvider.Decrypt(s, storeDecoder, modelEncoder),
+					mappingHints);
+			}
+		}
+
+		#endregion
+
+		#region Non-encrypting
+
+		private sealed class ByteConverter<T> : INeedStoreType<T>
+		{
+			public ByteConverter(Func<T, byte[]> decoder, Func<byte[], T> encoder)
+			{
+				Decoder = decoder ?? throw new ArgumentNullException(nameof(decoder));
+				Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+			}
+
+			private Func<T, byte[]> Decoder { get; }
+			private Func<byte[], T> Encoder { get; }
+
+			public void Deconstruct(out Func<T, byte[]> decoder, out Func<byte[], T> encoder)
+			{
+				decoder = Decoder;
+				encoder = Encoder;
+			}
+		}
+
+		private static class ByteConverter
+		{
+			public static ByteConverter<byte[]> Identity { get; } = new(b => b, b => b);
+			public static ByteConverter<string> Base64String { get; } = new(Convert.FromBase64String, Convert.ToBase64String);
+			public static ByteConverter<string> Utf8String { get; } = new(Encoding.UTF8.GetBytes, Encoding.UTF8.GetString);
+			public static ByteConverter<SecureString> Utf8SecureString { get; } = new(Encoding.UTF8.GetBytes, Encoding.UTF8.GetSecureString);
+
+			public static Stream WrapBytes(byte[] bytes) => new MemoryStream(bytes);
+		}
+
+		private sealed class NonEncryptionBuilder<TModelType, TStoreType> : IBuilder<TModelType, TStoreType>
+		{
+			public NonEncryptionBuilder(ByteConverter<TModelType> modelConverter, ByteConverter<TStoreType> storeConverter)
+			{
+				ModelConverter = modelConverter ?? throw new ArgumentNullException(nameof(modelConverter));
+				StoreConverter = storeConverter ?? throw new ArgumentNullException(nameof(storeConverter));
+			}
+
+			private ByteConverter<TModelType> ModelConverter { get; }
+			private ByteConverter<TStoreType> StoreConverter { get; }
+
+			/// <inheritdoc />
+			public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
+			{
+				var (modelDecoder, modelEncoder) = ModelConverter;
+				var (storeDecoder, storeEncoder) = StoreConverter;
+				return new ValueConverter<TModelType, TStoreType>(m => storeEncoder(modelDecoder(m)), s => modelEncoder(storeDecoder(s)), mappingHints);
+			}
+		}
+
+		#endregion
+
+		#region Standard Converters
+
+		internal static byte[] StreamToBytes(Stream stream)
+		{
+			if (stream is MemoryStream ms) return ms.ToArray();
+
+			using var output = new MemoryStream();
+			stream.CopyTo(output);
+			return output.ToArray();
+		}
+
+		internal static string StreamToBase64String(Stream stream) => Convert.ToBase64String(StreamToBytes(stream));
+
+		internal static string StreamToString(Stream stream)
+		{
+			using var reader = new StreamReader(stream, Encoding.UTF8);
+			return reader.ReadToEnd().Trim('\0');
+		}
+
+		internal static SecureString StreamToSecureString(Stream stream)
+		{
+			using var reader = new StreamReader(stream, Encoding.UTF8);
+
+			var result = new SecureString();
+			var buffer = new char[100];
+			while (!reader.EndOfStream)
+			{
+				var charsRead = reader.Read(buffer, 0, buffer.Length);
+				if (charsRead != 0)
+				{
+					for (int index = 0; index < charsRead; index++)
+					{
+						char c = buffer[index];
+						if (c != '\0') result.AppendChar(c);
+					}
+				}
+			}
+
+			return result;
+		}
+
+		#endregion
+
+		#region Builders
+
+		/// <summary>
+		/// Builds a converter for a property with a custom model type.
+		/// </summary>
+		/// <typeparam name="TModelType">
+		/// The model type.
+		/// </typeparam>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/>, if any.
+		/// </param>
+		/// <param name="decoder">
+		/// The function used to decode the model type to a byte array.
+		/// </param>
+		/// <param name="encoder">
+		/// The function used to encode a byte array to the model type.
+		/// </param>
+		/// <returns>
+		/// An <see cref="INeedStoreType{TModelType}"/> instance.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
+		/// </exception>
+		public static INeedStoreType<TModelType> From<TModelType>(
+			this IEncryptionProvider encryptionProvider,
+			Func<TModelType, byte[]> decoder,
+			Func<Stream, TModelType> encoder)
+		{
+			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
+			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
+			if (encryptionProvider is not null) return new NeedStoreType<TModelType>(encryptionProvider, decoder, encoder);
+			return new ByteConverter<TModelType>(decoder, b => encoder(ByteConverter.WrapBytes(b)));
+		}
+
+		/// <summary>
+		/// Builds a converter for a binary property.
+		/// </summary>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/>, if any.
+		/// </param>
+		/// <returns>
+		/// An <see cref="INeedStoreType{TModelType}"/> instance.
+		/// </returns>
+		public static INeedStoreType<byte[]> FromBinary(this IEncryptionProvider encryptionProvider)
+		{
+			if (encryptionProvider is null) return ByteConverter.Identity;
+			return new NeedStoreType<byte[]>(encryptionProvider, b => b, StreamToBytes);
+		}
+
+		/// <summary>
+		/// Builds a converter for a string property.
+		/// </summary>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/>, if any.
+		/// </param>
+		/// <returns>
+		/// An <see cref="INeedStoreType{TModelType}"/> instance.
+		/// </returns>
+		public static INeedStoreType<string> FromString(this IEncryptionProvider encryptionProvider)
+		{
+			if (encryptionProvider is null) return ByteConverter.Utf8String;
+			return new NeedStoreType<string>(encryptionProvider, Encoding.UTF8.GetBytes, StreamToString);
+		}
+
+		/// <summary>
+		/// Builds a converter for a <see cref="SecureString"/> property.
+		/// </summary>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/>, if any.
+		/// </param>
+		/// <returns>
+		/// An <see cref="INeedStoreType{TModelType}"/> instance.
+		/// </returns>
+		public static INeedStoreType<SecureString> FromSecureString(this IEncryptionProvider encryptionProvider)
+		{
+			if (encryptionProvider is null) return ByteConverter.Utf8SecureString;
+			return new NeedStoreType<SecureString>(encryptionProvider, Encoding.UTF8.GetBytes, StreamToSecureString);
+		}
+
+		/// <summary>
+		/// Specifies that the property should be stored in the database using a custom format.
+		/// </summary>
+		/// <typeparam name="TModelType">
+		/// The model type.
+		/// </typeparam>
+		/// <typeparam name="TStoreType">
+		/// The store type.
+		/// </typeparam>
+		/// <param name="modelType">
+		/// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
+		/// </param>
+		/// <param name="decoder">
+		/// The function used to decode the store type into a byte array.
+		/// </param>
+		/// <param name="encoder">
+		/// The function used to encode a byte array into the store type.
+		/// </param>
+		/// <returns>
+		/// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="modelType"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="decoder"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="encoder"/> is <see langword="null"/>.</para>
+		/// </exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="modelType"/> is not a supported type.
+		/// </exception>
+		public static IBuilder<TModelType, TStoreType> To<TModelType, TStoreType>(
+			INeedStoreType<TModelType> modelType,
+			Func<TStoreType, byte[]> decoder,
+			Func<Stream, TStoreType> encoder)
+		{
+			if (modelType is null) throw new ArgumentNullException(nameof(modelType));
+			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
+			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
+
+			return modelType switch
+			{
+				ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, TStoreType>(converter, new ByteConverter<TStoreType>(decoder, b => encoder(ByteConverter.WrapBytes(b)))),
+				NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, TStoreType>(converter, decoder, encoder),
+				_ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
+			};
+		}
+
+		/// <summary>
+		/// Specifies that the property should be stored in the database in binary.
+		/// </summary>
+		/// <typeparam name="TModelType">
+		/// The model type.
+		/// </typeparam>
+		/// <param name="modelType">
+		/// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
+		/// </param>
+		/// <returns>
+		/// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="modelType"/> is <see langword="null"/>.
+		/// </exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="modelType"/> is not a supported type.
+		/// </exception>
+		public static IBuilder<TModelType, byte[]> ToBinary<TModelType>(this INeedStoreType<TModelType> modelType) => modelType switch
+		{
+			// ReSharper disable once HeuristicUnreachableCode
+			null => throw new ArgumentNullException(nameof(modelType)),
+			ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, byte[]>(converter, ByteConverter.Identity),
+			NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, byte[]>(converter, b => b, StreamToBytes),
+			_ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
+		};
+
+		/// <summary>
+		/// Specifies that the property should be stored in the database in a Base64-encoded string.
+		/// </summary>
+		/// <typeparam name="TModelType">
+		/// The model type.
+		/// </typeparam>
+		/// <param name="modelType">
+		/// The <see cref="INeedStoreType{TModelType}"/> representing the model type.
+		/// </param>
+		/// <returns>
+		/// An <see cref="IBuilder{TModelType,TStoreType}"/> instance.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="modelType"/> is <see langword="null"/>.
+		/// </exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="modelType"/> is not a supported type.
+		/// </exception>
+		public static IBuilder<TModelType, string> ToBase64<TModelType>(this INeedStoreType<TModelType> modelType) => modelType switch
+		{
+			// ReSharper disable once HeuristicUnreachableCode
+			null => throw new ArgumentNullException(nameof(modelType)),
+			ByteConverter<TModelType> converter => new NonEncryptionBuilder<TModelType, string>(converter, ByteConverter.Base64String),
+			NeedStoreType<TModelType> converter => new EncryptionBuilder<TModelType, string>(converter, Convert.FromBase64String, StreamToBase64String),
+			_ => throw new ArgumentException($"Unsupported model type: {modelType}", nameof(modelType)),
+		};
+
+		#endregion
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`1.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`1.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
+{
+    /// <summary>
+    /// A converter builder class which has the model type specified.
+    /// </summary>
+    /// <typeparam name="TModelType">
+    /// The model type.
+    /// </typeparam>
+    public readonly struct ConverterBuilder<TModelType>
+    {
+        internal ConverterBuilder(IEncryptionProvider encryptionProvider, Func<TModelType, byte[]> decoder, Func<Stream, TModelType> encoder)
+        {
+            Debug.Assert(decoder is not null);
+            Debug.Assert(encoder is not null);
+
+            EncryptionProvider = encryptionProvider;
+            Decoder = decoder;
+            Encoder = encoder;
+        }
+
+        private IEncryptionProvider EncryptionProvider { get; }
+        private Func<TModelType, byte[]> Decoder { get; }
+        private Func<Stream, TModelType> Encoder { get; }
+        internal bool IsEmpty => Decoder is null || Encoder is null;
+
+        internal void Deconstruct(out IEncryptionProvider encryptionProvider, out Func<TModelType, byte[]> decoder, out Func<Stream, TModelType> encoder)
+        {
+            encryptionProvider = EncryptionProvider;
+            decoder = Decoder;
+            encoder = Encoder;
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`1.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`1.cs
@@ -22,9 +22,10 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
             Encoder = encoder;
         }
 
-        private IEncryptionProvider EncryptionProvider { get; }
-        private Func<TModelType, byte[]> Decoder { get; }
-        private Func<Stream, TModelType> Encoder { get; }
+        private readonly IEncryptionProvider EncryptionProvider;
+        private readonly Func<TModelType, byte[]> Decoder;
+        private readonly Func<Stream, TModelType> Encoder;
+
         internal bool IsEmpty => Decoder is null || Encoder is null;
 
         internal void Deconstruct(out IEncryptionProvider encryptionProvider, out Func<TModelType, byte[]> decoder, out Func<Stream, TModelType> encoder)

--- a/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`2.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`2.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
+{
+    /// <summary>
+    /// A converter builder class which has both the model type and store type specified.
+    /// </summary>
+    /// <typeparam name="TModelType">
+    /// The model type.
+    /// </typeparam>
+    /// <typeparam name="TStoreType">
+    /// The store type.
+    /// </typeparam>
+    public readonly struct ConverterBuilder<TModelType, TStoreType>
+    {
+        internal ConverterBuilder(ConverterBuilder<TModelType> modelType, Func<TStoreType, byte[]> decoder, Func<Stream, TStoreType> encoder)
+        {
+            Debug.Assert(!modelType.IsEmpty);
+            Debug.Assert(decoder is not null);
+            Debug.Assert(encoder is not null);
+
+            ModelType = modelType;
+            Decoder = decoder;
+            Encoder = encoder;
+        }
+
+        private ConverterBuilder<TModelType> ModelType { get; }
+        private Func<TStoreType, byte[]> Decoder { get; }
+        private Func<Stream, TStoreType> Encoder { get; }
+
+        /// <summary>
+        /// Builds the value converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        /// The mapping hints to use, if any.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ValueConverter{TModel,TProvider}"/>.
+        /// </returns>
+        public ValueConverter<TModelType, TStoreType> Build(ConverterMappingHints mappingHints = null)
+        {
+            var (encryptionProvider, modelDecoder, modelEncoder) = ModelType;
+            var storeDecoder = Decoder;
+            var storeEncoder = Encoder;
+
+            if (modelDecoder is null || modelEncoder is null || storeDecoder is null || storeEncoder is null)
+            {
+                return null;
+            }
+
+            if (encryptionProvider is null)
+            {
+                return new ValueConverter<TModelType, TStoreType>(
+                    m => storeEncoder(StandardConverters.BytesToStream(modelDecoder(m))), 
+                    s => modelEncoder(StandardConverters.BytesToStream(storeDecoder(s))), 
+                    mappingHints);
+            }
+
+            return new EncryptionConverter<TModelType, TStoreType>(
+                encryptionProvider,
+                m => encryptionProvider.Encrypt(m, modelDecoder, storeEncoder),
+                s => encryptionProvider.Decrypt(s, storeDecoder, modelEncoder),
+                mappingHints);
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`2.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/ConverterBuilder`2.cs
@@ -27,9 +27,9 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
             Encoder = encoder;
         }
 
-        private ConverterBuilder<TModelType> ModelType { get; }
-        private Func<TStoreType, byte[]> Decoder { get; }
-        private Func<Stream, TStoreType> Encoder { get; }
+        private readonly ConverterBuilder<TModelType> ModelType;
+        private readonly Func<TStoreType, byte[]> Decoder;
+        private readonly Func<Stream, TStoreType> Encoder;
 
         /// <summary>
         /// Builds the value converter.

--- a/src/EntityFrameworkCore.DataEncryption/Internal/EncodingExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/EncodingExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
+{
+	internal static class EncodingExtensions
+	{
+		public static byte[] GetBytes(this Encoding encoding, SecureString value)
+		{
+			if (encoding is null) throw new ArgumentNullException(nameof(encoding));
+			if (value is null || value.Length == 0) return Array.Empty<byte>();
+
+			IntPtr valuePtr = IntPtr.Zero;
+			try
+			{
+				valuePtr = Marshal.SecureStringToGlobalAllocUnicode(value);
+				if (valuePtr == IntPtr.Zero) return Array.Empty<byte>();
+
+				unsafe
+				{
+					char* chars = (char*)valuePtr;
+					Debug.Assert(chars != null);
+
+					int byteCount = encoding.GetByteCount(chars, value.Length);
+
+					var result = new byte[byteCount];
+					fixed (byte* bytes = result)
+					{
+						encoding.GetBytes(chars, value.Length, bytes, byteCount);
+					}
+
+					return result;
+				}
+			}
+			finally
+			{
+				if (valuePtr != IntPtr.Zero)
+				{
+					Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+				}
+			}
+		}
+
+		public static SecureString GetSecureString(this Encoding encoding, byte[] bytes)
+		{
+			if (encoding is null) throw new ArgumentNullException(nameof(encoding));
+			if (bytes is null || bytes.Length == 0) return default;
+
+			unsafe
+			{
+				fixed (byte* pB = bytes)
+				{
+					int charCount = encoding.GetCharCount(pB, bytes.Length);
+					Span<char> chars = charCount < 1024 ? stackalloc char[charCount] : new char[charCount];
+					fixed (char* pC = &MemoryMarshal.GetReference(chars))
+					{
+						charCount = encoding.GetChars(pB, bytes.Length, pC, chars.Length);
+						return new SecureString(pC, charCount);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/Internal/EncodingExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/EncodingExtensions.cs
@@ -6,62 +6,79 @@ using System.Text;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
 {
-	internal static class EncodingExtensions
-	{
-		public static byte[] GetBytes(this Encoding encoding, SecureString value)
-		{
-			if (encoding is null) throw new ArgumentNullException(nameof(encoding));
-			if (value is null || value.Length == 0) return Array.Empty<byte>();
+    internal static class EncodingExtensions
+    {
+        public static byte[] GetBytes(this Encoding encoding, SecureString value)
+        {
+            if (encoding is null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
 
-			IntPtr valuePtr = IntPtr.Zero;
-			try
-			{
-				valuePtr = Marshal.SecureStringToGlobalAllocUnicode(value);
-				if (valuePtr == IntPtr.Zero) return Array.Empty<byte>();
+            if (value is null || value.Length == 0)
+            {
+                return Array.Empty<byte>();
+            }
 
-				unsafe
-				{
-					char* chars = (char*)valuePtr;
-					Debug.Assert(chars != null);
+            IntPtr valuePtr = IntPtr.Zero;
+            try
+            {
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(value);
+                if (valuePtr == IntPtr.Zero)
+                {
+                    return Array.Empty<byte>();
+                }
 
-					int byteCount = encoding.GetByteCount(chars, value.Length);
+                unsafe
+                {
+                    char* chars = (char*)valuePtr;
+                    Debug.Assert(chars != null);
 
-					var result = new byte[byteCount];
-					fixed (byte* bytes = result)
-					{
-						encoding.GetBytes(chars, value.Length, bytes, byteCount);
-					}
+                    int byteCount = encoding.GetByteCount(chars, value.Length);
 
-					return result;
-				}
-			}
-			finally
-			{
-				if (valuePtr != IntPtr.Zero)
-				{
-					Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
-				}
-			}
-		}
+                    var result = new byte[byteCount];
+                    fixed (byte* bytes = result)
+                    {
+                        encoding.GetBytes(chars, value.Length, bytes, byteCount);
+                    }
 
-		public static SecureString GetSecureString(this Encoding encoding, byte[] bytes)
-		{
-			if (encoding is null) throw new ArgumentNullException(nameof(encoding));
-			if (bytes is null || bytes.Length == 0) return default;
+                    return result;
+                }
+            }
+            finally
+            {
+                if (valuePtr != IntPtr.Zero)
+                {
+                    Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+                }
+            }
+        }
 
-			unsafe
-			{
-				fixed (byte* pB = bytes)
-				{
-					int charCount = encoding.GetCharCount(pB, bytes.Length);
-					Span<char> chars = charCount < 1024 ? stackalloc char[charCount] : new char[charCount];
-					fixed (char* pC = &MemoryMarshal.GetReference(chars))
-					{
-						charCount = encoding.GetChars(pB, bytes.Length, pC, chars.Length);
-						return new SecureString(pC, charCount);
-					}
-				}
-			}
-		}
-	}
+        public static SecureString GetSecureString(this Encoding encoding, byte[] bytes)
+        {
+            if (encoding is null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            if (bytes is null || bytes.Length == 0)
+            {
+                return default;
+            }
+
+            unsafe
+            {
+                fixed (byte* pB = bytes)
+                {
+                    int charCount = encoding.GetCharCount(pB, bytes.Length);
+                    Span<char> chars = charCount < 1024 ? stackalloc char[charCount] : new char[charCount];
+                    fixed (char* pC = &MemoryMarshal.GetReference(chars))
+                    {
+                        charCount = encoding.GetChars(pB, bytes.Length, pC, chars.Length);
+                        return new SecureString(pC, charCount);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/EncodingExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/EncodingExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
 {
     internal static class EncodingExtensions
     {
-        public static byte[] GetBytes(this Encoding encoding, SecureString value)
+        internal static byte[] GetBytes(this Encoding encoding, SecureString value)
         {
             if (encoding is null)
             {
@@ -50,33 +50,6 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
                 if (valuePtr != IntPtr.Zero)
                 {
                     Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
-                }
-            }
-        }
-
-        public static SecureString GetSecureString(this Encoding encoding, byte[] bytes)
-        {
-            if (encoding is null)
-            {
-                throw new ArgumentNullException(nameof(encoding));
-            }
-
-            if (bytes is null || bytes.Length == 0)
-            {
-                return default;
-            }
-
-            unsafe
-            {
-                fixed (byte* pB = bytes)
-                {
-                    int charCount = encoding.GetCharCount(pB, bytes.Length);
-                    Span<char> chars = charCount < 1024 ? stackalloc char[charCount] : new char[charCount];
-                    fixed (char* pC = &MemoryMarshal.GetReference(chars))
-                    {
-                        charCount = encoding.GetChars(pB, bytes.Length, pC, chars.Length);
-                        return new SecureString(pC, charCount);
-                    }
                 }
             }
         }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/EncryptionConverter.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/EncryptionConverter.cs
@@ -1,20 +1,28 @@
-﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+﻿using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
 {
-    /// <summary>
-    /// Defines the internal encryption converter for string values.
-    /// </summary>
-    internal sealed class EncryptionConverter : ValueConverter<string, string>
-    {
-        /// <summary>
-        /// Creates a new <see cref="EncryptionConverter"/> instance.
-        /// </summary>
-        /// <param name="encryptionProvider">Encryption provider</param>
-        /// <param name="mappingHints">Entity Framework mapping hints</param>
-        public EncryptionConverter(IEncryptionProvider encryptionProvider, ConverterMappingHints mappingHints = null) 
-            : base(x => encryptionProvider.Encrypt(x), x => encryptionProvider.Decrypt(x), mappingHints)
-        {
-        }
-    }
+	/// <summary>
+	/// Defines the internal encryption converter for string values.
+	/// </summary>
+	internal sealed class EncryptionConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>, IEncryptionValueConverter
+	{
+		/// <summary>
+		/// Creates a new <see cref="EncryptionConverter{TModel,TProvider}"/> instance.
+		/// </summary>
+		public EncryptionConverter(
+			IEncryptionProvider encryptionProvider,
+			Expression<Func<TModel, TProvider>> convertToProviderExpression,
+			Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+			ConverterMappingHints mappingHints = null) 
+			: base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+		{
+			EncryptionProvider = encryptionProvider;
+		}
+
+		/// <inheritdoc />
+		public IEncryptionProvider EncryptionProvider { get; }
+	}
 }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/EncryptionConverter.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/EncryptionConverter.cs
@@ -4,25 +4,25 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
 {
-	/// <summary>
-	/// Defines the internal encryption converter for string values.
-	/// </summary>
-	internal sealed class EncryptionConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>, IEncryptionValueConverter
-	{
-		/// <summary>
-		/// Creates a new <see cref="EncryptionConverter{TModel,TProvider}"/> instance.
-		/// </summary>
-		public EncryptionConverter(
-			IEncryptionProvider encryptionProvider,
-			Expression<Func<TModel, TProvider>> convertToProviderExpression,
-			Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-			ConverterMappingHints mappingHints = null) 
-			: base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
-		{
-			EncryptionProvider = encryptionProvider;
-		}
+    /// <summary>
+    /// Defines the internal encryption converter for string values.
+    /// </summary>
+    internal sealed class EncryptionConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>, IEncryptionValueConverter
+    {
+        /// <summary>
+        /// Creates a new <see cref="EncryptionConverter{TModel,TProvider}"/> instance.
+        /// </summary>
+        public EncryptionConverter(
+            IEncryptionProvider encryptionProvider,
+            Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            ConverterMappingHints mappingHints = null) 
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+            EncryptionProvider = encryptionProvider;
+        }
 
-		/// <inheritdoc />
-		public IEncryptionProvider EncryptionProvider { get; }
-	}
+        /// <inheritdoc />
+        public IEncryptionProvider EncryptionProvider { get; }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/IEncryptionValueConverter.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/IEncryptionValueConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
+{
+	/// <summary>
+	/// Interface for an encryption value converter.
+	/// </summary>
+	public interface IEncryptionValueConverter
+	{
+		/// <summary>
+		/// Returns the encryption provider, if any.
+		/// </summary>
+		/// <value>
+		/// The <see cref="IEncryptionProvider"/> for this converter, if any.
+		/// </value>
+		IEncryptionProvider EncryptionProvider { get; }
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/Internal/IEncryptionValueConverter.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/IEncryptionValueConverter.cs
@@ -2,17 +2,17 @@
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
 {
-	/// <summary>
-	/// Interface for an encryption value converter.
-	/// </summary>
-	public interface IEncryptionValueConverter
-	{
-		/// <summary>
-		/// Returns the encryption provider, if any.
-		/// </summary>
-		/// <value>
-		/// The <see cref="IEncryptionProvider"/> for this converter, if any.
-		/// </value>
-		IEncryptionProvider EncryptionProvider { get; }
-	}
+    /// <summary>
+    /// Interface for an encryption value converter.
+    /// </summary>
+    public interface IEncryptionValueConverter
+    {
+        /// <summary>
+        /// Returns the encryption provider, if any.
+        /// </summary>
+        /// <value>
+        /// The <see cref="IEncryptionProvider"/> for this converter, if any.
+        /// </value>
+        IEncryptionProvider EncryptionProvider { get; }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Internal/StandardConverters.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/StandardConverters.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Security;
+using System.Text;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Internal
+{
+    internal static class StandardConverters
+    {
+        internal static Stream BytesToStream(byte[] bytes) => new MemoryStream(bytes);
+
+        internal static byte[] StreamToBytes(Stream stream)
+        {
+            if (stream is MemoryStream ms)
+            {
+                return ms.ToArray();
+            }
+
+            using var output = new MemoryStream();
+            stream.CopyTo(output);
+            return output.ToArray();
+        }
+
+        internal static string StreamToBase64String(Stream stream) => Convert.ToBase64String(StreamToBytes(stream));
+
+        internal static string StreamToString(Stream stream)
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd().Trim('\0');
+        }
+
+        internal static SecureString StreamToSecureString(Stream stream)
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+
+            var result = new SecureString();
+            var buffer = new char[100];
+            while (!reader.EndOfStream)
+            {
+                var charsRead = reader.Read(buffer, 0, buffer.Length);
+                if (charsRead != 0)
+                {
+                    for (int index = 0; index < charsRead; index++)
+                    {
+                        char c = buffer[index];
+                        if (c != '\0')
+                        {
+                            result.AppendChar(c);
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
+{
+	/// <summary>
+	/// Utilities for migrating encrypted data from one provider to another.
+	/// </summary>
+	/// <example>
+	/// <para>To migrate from v1 to v2 of <see cref="AesProvider"/>:</para>
+	/// <code>
+	/// var sourceProvider = new AesProvider(key, iv);
+	/// var destinationProvider = new AesProvider(key);
+	/// var migrationProvider = new MigrationEncryptionProvider(sourceProvider, destinationProvider);
+	/// await using var migrationContext = new DatabaseContext(options, migrationProvider);
+	/// await migrationContext.MigrateAsync(logger, cancellationToken);
+	/// </code>
+	/// </example>
+	public static class EncryptionMigrator
+	{
+		private static readonly MethodInfo SetMethod = typeof(DbContext).GetMethod(nameof(DbContext.Set));
+
+		private static IQueryable<object> Set(this DbContext context, IEntityType entityType)
+		{
+			var method = SetMethod.MakeGenericMethod(entityType.ClrType);
+			var result = method.Invoke(context, null);
+			return (IQueryable<object>)result;
+		}
+
+		/// <summary>
+		/// Migrates the data for a single property to a new encryption provider.
+		/// </summary>
+		/// <param name="context">
+		/// The <see cref="DbContext"/>.
+		/// </param>
+		/// <param name="property">
+		/// The <see cref="IProperty"/> to migrate.
+		/// </param>
+		/// <param name="logger">
+		/// The <see cref="ILogger"/> to use, if any.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// The <see cref="CancellationToken"/> to use, if any.
+		/// </param>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="context"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="property"/> is <see langword="null"/>.</para>
+		/// </exception>
+		public static async Task MigrateAsync(this DbContext context, IProperty property, ILogger logger = default, CancellationToken cancellationToken = default)
+		{
+			if (context is null) throw new ArgumentNullException(nameof(context));
+			if (property is null) throw new ArgumentNullException(nameof(property));
+
+			if (property.GetValueConverter() is not IEncryptionValueConverter converter)
+			{
+				logger?.LogWarning("Property {Property} on entity type {EntityType} is not using an encryption value converter. ({Converter})",
+					property.Name, property.DeclaringEntityType.Name, property.GetValueConverter());
+
+				return;
+			}
+
+			if (converter.EncryptionProvider is not MigrationEncryptionProvider { IsEmpty: false })
+			{
+				logger?.LogWarning("Property {Property} on entity type {EntityType} is not using a non-empty migration encryption value converter. ({EncryptionProvider})",
+					property.Name, property.DeclaringEntityType.Name, converter.EncryptionProvider);
+
+				return;
+			}
+
+			logger?.LogInformation("Loading data for {EntityType} ({Property})...",
+				property.DeclaringEntityType.Name, property.Name);
+
+			var set = context.Set(property.DeclaringEntityType);
+			var list = await set.ToListAsync(cancellationToken);
+
+			logger?.LogInformation("Migrating data for {EntityType} :: {Property}} ({RecordCount} records)...",
+				property.DeclaringEntityType.Name, property.Name, list.Count);
+
+			foreach (var entity in list)
+			{
+				context.Entry(entity).Property(property.Name).IsModified = true;
+			}
+
+			await context.SaveChangesAsync(cancellationToken);
+		}
+
+		private static async ValueTask MigrateAsyncCore(DbContext context, IEntityType entityType, ILogger logger = default, CancellationToken cancellationToken = default)
+		{
+			if (context is null) throw new ArgumentNullException(nameof(context));
+			if (entityType is null) throw new ArgumentNullException(nameof(entityType));
+
+			var encryptedProperties = entityType.GetProperties()
+				.Select(p => (property: p, encryptionProvider: (p.GetValueConverter() as IEncryptionValueConverter)?.EncryptionProvider))
+				.Where(p => p.encryptionProvider is MigrationEncryptionProvider { IsEmpty: false })
+				.Select(p => p.property)
+				.ToList();
+
+			if (encryptedProperties.Count == 0)
+			{
+				logger?.LogDebug("Entity type {EntityType} has no encrypted properties.", entityType.Name);
+				return;
+			}
+
+			logger?.LogInformation("Loading data for {EntityType} ({PropertyCount} properties)...", entityType.Name, encryptedProperties.Count);
+
+			var set = context.Set(entityType);
+			var list = await set.ToListAsync(cancellationToken);
+			logger?.LogInformation("Migrating data for {EntityType} ({RecordCount} records)...", entityType.Name, list.Count);
+
+			foreach (var entity in list)
+			{
+				var entry = context.Entry(entity);
+				foreach (var property in encryptedProperties)
+				{
+					entry.Property(property.Name).IsModified = true;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Migrates the encrypted data for a single entity type to a new encryption provider.
+		/// </summary>
+		/// <param name="context">
+		/// The <see cref="DbContext"/>.
+		/// </param>
+		/// <param name="entityType">
+		/// The <see cref="IEntityType"/> to migrate.
+		/// </param>
+		/// <param name="logger">
+		/// The <see cref="ILogger"/> to use, if any.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// The <see cref="CancellationToken"/> to use, if any.
+		/// </param>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="context"/> is <see langword="null"/>.</para>
+		/// <para>-or-</para>
+		/// <para><paramref name="entityType"/> is <see langword="null"/>.</para>
+		/// </exception>
+		public static async Task MigrateAsync(this DbContext context, IEntityType entityType, ILogger logger = default, CancellationToken cancellationToken = default)
+		{
+			if (context is null) throw new ArgumentNullException(nameof(context));
+			if (entityType is null) throw new ArgumentNullException(nameof(entityType));
+
+			await MigrateAsyncCore(context, entityType, logger, cancellationToken);
+			await context.SaveChangesAsync(cancellationToken);
+		}
+
+		/// <summary>
+		/// Migrates the encrypted data for the entire context to a new encryption provider.
+		/// </summary>
+		/// <param name="context">
+		/// The <see cref="DbContext"/>.
+		/// </param>
+		/// <param name="logger">
+		/// The <see cref="ILogger"/> to use, if any.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// The <see cref="CancellationToken"/> to use, if any.
+		/// </param>
+		/// <exception cref="ArgumentNullException">
+		/// <para><paramref name="context"/> is <see langword="null"/>.</para>
+		/// </exception>
+		public static async Task MigrateAsync(this DbContext context, ILogger logger = default, CancellationToken cancellationToken = default)
+		{
+			if (context is null) throw new ArgumentNullException(nameof(context));
+
+			foreach (var entityType in context.Model.GetEntityTypes())
+			{
+				await MigrateAsyncCore(context, entityType, logger, cancellationToken);
+			}
+
+			await context.SaveChangesAsync(cancellationToken);
+		}
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
@@ -10,175 +10,199 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
 {
-	/// <summary>
-	/// Utilities for migrating encrypted data from one provider to another.
-	/// </summary>
-	/// <example>
-	/// <para>To migrate from v1 to v2 of <see cref="AesProvider"/>:</para>
-	/// <code>
-	/// var sourceProvider = new AesProvider(key, iv);
-	/// var destinationProvider = new AesProvider(key);
-	/// var migrationProvider = new MigrationEncryptionProvider(sourceProvider, destinationProvider);
-	/// await using var migrationContext = new DatabaseContext(options, migrationProvider);
-	/// await migrationContext.MigrateAsync(logger, cancellationToken);
-	/// </code>
-	/// </example>
-	public static class EncryptionMigrator
-	{
-		private static readonly MethodInfo SetMethod = typeof(DbContext).GetMethod(nameof(DbContext.Set));
+    /// <summary>
+    /// Utilities for migrating encrypted data from one provider to another.
+    /// </summary>
+    /// <example>
+    /// <para>To migrate from v1 to v2 of <see cref="AesProvider"/>:</para>
+    /// <code>
+    /// var sourceProvider = new AesProvider(key, iv);
+    /// var destinationProvider = new AesProvider(key);
+    /// var migrationProvider = new MigrationEncryptionProvider(sourceProvider, destinationProvider);
+    /// await using var migrationContext = new DatabaseContext(options, migrationProvider);
+    /// await migrationContext.MigrateAsync(logger, cancellationToken);
+    /// </code>
+    /// </example>
+    public static class EncryptionMigrator
+    {
+        private static readonly MethodInfo SetMethod = typeof(DbContext).GetMethod(nameof(DbContext.Set));
 
-		private static IQueryable<object> Set(this DbContext context, IEntityType entityType)
-		{
-			var method = SetMethod.MakeGenericMethod(entityType.ClrType);
-			var result = method.Invoke(context, null);
-			return (IQueryable<object>)result;
-		}
+        private static IQueryable<object> Set(this DbContext context, IEntityType entityType)
+        {
+            var method = SetMethod.MakeGenericMethod(entityType.ClrType);
+            var result = method.Invoke(context, null);
+            return (IQueryable<object>)result;
+        }
 
-		/// <summary>
-		/// Migrates the data for a single property to a new encryption provider.
-		/// </summary>
-		/// <param name="context">
-		/// The <see cref="DbContext"/>.
-		/// </param>
-		/// <param name="property">
-		/// The <see cref="IProperty"/> to migrate.
-		/// </param>
-		/// <param name="logger">
-		/// The <see cref="ILogger"/> to use, if any.
-		/// </param>
-		/// <param name="cancellationToken">
-		/// The <see cref="CancellationToken"/> to use, if any.
-		/// </param>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="context"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="property"/> is <see langword="null"/>.</para>
-		/// </exception>
-		public static async Task MigrateAsync(this DbContext context, IProperty property, ILogger logger = default, CancellationToken cancellationToken = default)
-		{
-			if (context is null) throw new ArgumentNullException(nameof(context));
-			if (property is null) throw new ArgumentNullException(nameof(property));
+        /// <summary>
+        /// Migrates the data for a single property to a new encryption provider.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="DbContext"/>.
+        /// </param>
+        /// <param name="property">
+        /// The <see cref="IProperty"/> to migrate.
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to use, if any.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> to use, if any.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="context"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="property"/> is <see langword="null"/>.</para>
+        /// </exception>
+        public static async Task MigrateAsync(this DbContext context, IProperty property, ILogger logger = default, CancellationToken cancellationToken = default)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
-			if (property.GetValueConverter() is not IEncryptionValueConverter converter)
-			{
-				logger?.LogWarning("Property {Property} on entity type {EntityType} is not using an encryption value converter. ({Converter})",
-					property.Name, property.DeclaringEntityType.Name, property.GetValueConverter());
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
-				return;
-			}
+            if (property.GetValueConverter() is not IEncryptionValueConverter converter)
+            {
+                logger?.LogWarning("Property {Property} on entity type {EntityType} is not using an encryption value converter. ({Converter})",
+                    property.Name, property.DeclaringEntityType.Name, property.GetValueConverter());
 
-			if (converter.EncryptionProvider is not MigrationEncryptionProvider { IsEmpty: false })
-			{
-				logger?.LogWarning("Property {Property} on entity type {EntityType} is not using a non-empty migration encryption value converter. ({EncryptionProvider})",
-					property.Name, property.DeclaringEntityType.Name, converter.EncryptionProvider);
+                return;
+            }
 
-				return;
-			}
+            if (converter.EncryptionProvider is not MigrationEncryptionProvider { IsEmpty: false })
+            {
+                logger?.LogWarning("Property {Property} on entity type {EntityType} is not using a non-empty migration encryption value converter. ({EncryptionProvider})",
+                    property.Name, property.DeclaringEntityType.Name, converter.EncryptionProvider);
 
-			logger?.LogInformation("Loading data for {EntityType} ({Property})...",
-				property.DeclaringEntityType.Name, property.Name);
+                return;
+            }
 
-			var set = context.Set(property.DeclaringEntityType);
-			var list = await set.ToListAsync(cancellationToken);
+            logger?.LogInformation("Loading data for {EntityType} ({Property})...",
+                property.DeclaringEntityType.Name, property.Name);
 
-			logger?.LogInformation("Migrating data for {EntityType} :: {Property}} ({RecordCount} records)...",
-				property.DeclaringEntityType.Name, property.Name, list.Count);
+            var set = context.Set(property.DeclaringEntityType);
+            var list = await set.ToListAsync(cancellationToken);
 
-			foreach (var entity in list)
-			{
-				context.Entry(entity).Property(property.Name).IsModified = true;
-			}
+            logger?.LogInformation("Migrating data for {EntityType} :: {Property}} ({RecordCount} records)...",
+                property.DeclaringEntityType.Name, property.Name, list.Count);
 
-			await context.SaveChangesAsync(cancellationToken);
-		}
+            foreach (var entity in list)
+            {
+                context.Entry(entity).Property(property.Name).IsModified = true;
+            }
 
-		private static async ValueTask MigrateAsyncCore(DbContext context, IEntityType entityType, ILogger logger = default, CancellationToken cancellationToken = default)
-		{
-			if (context is null) throw new ArgumentNullException(nameof(context));
-			if (entityType is null) throw new ArgumentNullException(nameof(entityType));
+            await context.SaveChangesAsync(cancellationToken);
+        }
 
-			var encryptedProperties = entityType.GetProperties()
-				.Select(p => (property: p, encryptionProvider: (p.GetValueConverter() as IEncryptionValueConverter)?.EncryptionProvider))
-				.Where(p => p.encryptionProvider is MigrationEncryptionProvider { IsEmpty: false })
-				.Select(p => p.property)
-				.ToList();
+        private static async ValueTask MigrateAsyncCore(DbContext context, IEntityType entityType, ILogger logger = default, CancellationToken cancellationToken = default)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
-			if (encryptedProperties.Count == 0)
-			{
-				logger?.LogDebug("Entity type {EntityType} has no encrypted properties.", entityType.Name);
-				return;
-			}
+            if (entityType is null)
+            {
+                throw new ArgumentNullException(nameof(entityType));
+            }
 
-			logger?.LogInformation("Loading data for {EntityType} ({PropertyCount} properties)...", entityType.Name, encryptedProperties.Count);
+            var encryptedProperties = entityType.GetProperties()
+                .Select(p => (property: p, encryptionProvider: (p.GetValueConverter() as IEncryptionValueConverter)?.EncryptionProvider))
+                .Where(p => p.encryptionProvider is MigrationEncryptionProvider { IsEmpty: false })
+                .Select(p => p.property)
+                .ToList();
 
-			var set = context.Set(entityType);
-			var list = await set.ToListAsync(cancellationToken);
-			logger?.LogInformation("Migrating data for {EntityType} ({RecordCount} records)...", entityType.Name, list.Count);
+            if (encryptedProperties.Count == 0)
+            {
+                logger?.LogDebug("Entity type {EntityType} has no encrypted properties.", entityType.Name);
+                return;
+            }
 
-			foreach (var entity in list)
-			{
-				var entry = context.Entry(entity);
-				foreach (var property in encryptedProperties)
-				{
-					entry.Property(property.Name).IsModified = true;
-				}
-			}
-		}
+            logger?.LogInformation("Loading data for {EntityType} ({PropertyCount} properties)...", entityType.Name, encryptedProperties.Count);
 
-		/// <summary>
-		/// Migrates the encrypted data for a single entity type to a new encryption provider.
-		/// </summary>
-		/// <param name="context">
-		/// The <see cref="DbContext"/>.
-		/// </param>
-		/// <param name="entityType">
-		/// The <see cref="IEntityType"/> to migrate.
-		/// </param>
-		/// <param name="logger">
-		/// The <see cref="ILogger"/> to use, if any.
-		/// </param>
-		/// <param name="cancellationToken">
-		/// The <see cref="CancellationToken"/> to use, if any.
-		/// </param>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="context"/> is <see langword="null"/>.</para>
-		/// <para>-or-</para>
-		/// <para><paramref name="entityType"/> is <see langword="null"/>.</para>
-		/// </exception>
-		public static async Task MigrateAsync(this DbContext context, IEntityType entityType, ILogger logger = default, CancellationToken cancellationToken = default)
-		{
-			if (context is null) throw new ArgumentNullException(nameof(context));
-			if (entityType is null) throw new ArgumentNullException(nameof(entityType));
+            var set = context.Set(entityType);
+            var list = await set.ToListAsync(cancellationToken);
+            logger?.LogInformation("Migrating data for {EntityType} ({RecordCount} records)...", entityType.Name, list.Count);
 
-			await MigrateAsyncCore(context, entityType, logger, cancellationToken);
-			await context.SaveChangesAsync(cancellationToken);
-		}
+            foreach (var entity in list)
+            {
+                var entry = context.Entry(entity);
+                foreach (var property in encryptedProperties)
+                {
+                    entry.Property(property.Name).IsModified = true;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Migrates the encrypted data for the entire context to a new encryption provider.
-		/// </summary>
-		/// <param name="context">
-		/// The <see cref="DbContext"/>.
-		/// </param>
-		/// <param name="logger">
-		/// The <see cref="ILogger"/> to use, if any.
-		/// </param>
-		/// <param name="cancellationToken">
-		/// The <see cref="CancellationToken"/> to use, if any.
-		/// </param>
-		/// <exception cref="ArgumentNullException">
-		/// <para><paramref name="context"/> is <see langword="null"/>.</para>
-		/// </exception>
-		public static async Task MigrateAsync(this DbContext context, ILogger logger = default, CancellationToken cancellationToken = default)
-		{
-			if (context is null) throw new ArgumentNullException(nameof(context));
+        /// <summary>
+        /// Migrates the encrypted data for a single entity type to a new encryption provider.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="DbContext"/>.
+        /// </param>
+        /// <param name="entityType">
+        /// The <see cref="IEntityType"/> to migrate.
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to use, if any.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> to use, if any.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="context"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="entityType"/> is <see langword="null"/>.</para>
+        /// </exception>
+        public static async Task MigrateAsync(this DbContext context, IEntityType entityType, ILogger logger = default, CancellationToken cancellationToken = default)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
-			foreach (var entityType in context.Model.GetEntityTypes())
-			{
-				await MigrateAsyncCore(context, entityType, logger, cancellationToken);
-			}
+            if (entityType is null)
+            {
+                throw new ArgumentNullException(nameof(entityType));
+            }
 
-			await context.SaveChangesAsync(cancellationToken);
-		}
-	}
+            await MigrateAsyncCore(context, entityType, logger, cancellationToken);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Migrates the encrypted data for the entire context to a new encryption provider.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="DbContext"/>.
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to use, if any.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> to use, if any.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="context"/> is <see langword="null"/>.</para>
+        /// </exception>
+        public static async Task MigrateAsync(this DbContext context, ILogger logger = default, CancellationToken cancellationToken = default)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            foreach (var entityType in context.Model.GetEntityTypes())
+            {
+                await MigrateAsyncCore(context, entityType, logger, cancellationToken);
+            }
+
+            await context.SaveChangesAsync(cancellationToken);
+        }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/Migration/MigrationEncryptionProvider.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/MigrationEncryptionProvider.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
+{
+	/// <summary>
+	/// An encryption provided used for migrating from one encryption scheme to another.
+	/// </summary>
+	public class MigrationEncryptionProvider : IEncryptionProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MigrationEncryptionProvider" /> class.
+		/// </summary>
+		/// <param name="sourceEncryptionProvider">The source encryption provider.</param>
+		/// <param name="destinationEncryptionProvider">The destination encryption provider.</param>
+		public MigrationEncryptionProvider(
+			IEncryptionProvider sourceEncryptionProvider,
+			IEncryptionProvider destinationEncryptionProvider)
+		{
+			SourceEncryptionProvider = sourceEncryptionProvider;
+			DestinationEncryptionProvider = destinationEncryptionProvider;
+		}
+
+		/// <summary>
+		/// Returns the original encryption provider, if any.
+		/// </summary>
+		/// <value>
+		/// The original <see cref="IEncryptionProvider"/>, if any.
+		/// </value>
+		public IEncryptionProvider SourceEncryptionProvider { get; }
+
+		/// <summary>
+		/// Returns the new encryption provider, if any.
+		/// </summary>
+		/// <value>
+		/// The new <see cref="IEncryptionProvider"/>, if any.
+		/// </value>
+		public IEncryptionProvider DestinationEncryptionProvider { get; }
+
+		/// <summary>
+		/// Returns a flag indicating whether this provider is empty.
+		/// </summary>
+		/// <value>
+		/// <see langword="true"/> if this provider is empty;
+		/// otherwise, <see langword="false"/>.
+		/// </value>
+		public bool IsEmpty => SourceEncryptionProvider is null && DestinationEncryptionProvider is null;
+
+		/// <inheritdoc />
+		public TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter)
+		{
+			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
+			if (converter is null) throw new ArgumentNullException(nameof(converter));
+
+			if (SourceEncryptionProvider is not null)
+			{
+				return SourceEncryptionProvider.Decrypt(dataToDecrypt, decoder, converter);
+			}
+
+			byte[] data = decoder(dataToDecrypt);
+			if (data is null || data.Length == 0) return default;
+
+			using var ms = new MemoryStream(data);
+			return converter(ms);
+		}
+
+		/// <inheritdoc />
+		public TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder)
+		{
+			if (converter is null) throw new ArgumentNullException(nameof(converter));
+			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
+
+			if (DestinationEncryptionProvider is not null)
+			{
+				return DestinationEncryptionProvider.Encrypt(dataToEncrypt, converter, encoder);
+			}
+
+			byte[] data = converter(dataToEncrypt);
+			if (data is null || data.Length == 0) return default;
+
+			using var ms = new MemoryStream(data);
+			return encoder(ms);
+		}
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/Migration/MigrationEncryptionProvider.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/MigrationEncryptionProvider.cs
@@ -3,83 +3,103 @@ using System.IO;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
 {
-	/// <summary>
-	/// An encryption provided used for migrating from one encryption scheme to another.
-	/// </summary>
-	public class MigrationEncryptionProvider : IEncryptionProvider
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="MigrationEncryptionProvider" /> class.
-		/// </summary>
-		/// <param name="sourceEncryptionProvider">The source encryption provider.</param>
-		/// <param name="destinationEncryptionProvider">The destination encryption provider.</param>
-		public MigrationEncryptionProvider(
-			IEncryptionProvider sourceEncryptionProvider,
-			IEncryptionProvider destinationEncryptionProvider)
-		{
-			SourceEncryptionProvider = sourceEncryptionProvider;
-			DestinationEncryptionProvider = destinationEncryptionProvider;
-		}
+    /// <summary>
+    /// An encryption provided used for migrating from one encryption scheme to another.
+    /// </summary>
+    public class MigrationEncryptionProvider : IEncryptionProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrationEncryptionProvider" /> class.
+        /// </summary>
+        /// <param name="sourceEncryptionProvider">The source encryption provider.</param>
+        /// <param name="destinationEncryptionProvider">The destination encryption provider.</param>
+        public MigrationEncryptionProvider(
+            IEncryptionProvider sourceEncryptionProvider,
+            IEncryptionProvider destinationEncryptionProvider)
+        {
+            SourceEncryptionProvider = sourceEncryptionProvider;
+            DestinationEncryptionProvider = destinationEncryptionProvider;
+        }
 
-		/// <summary>
-		/// Returns the original encryption provider, if any.
-		/// </summary>
-		/// <value>
-		/// The original <see cref="IEncryptionProvider"/>, if any.
-		/// </value>
-		public IEncryptionProvider SourceEncryptionProvider { get; }
+        /// <summary>
+        /// Returns the original encryption provider, if any.
+        /// </summary>
+        /// <value>
+        /// The original <see cref="IEncryptionProvider"/>, if any.
+        /// </value>
+        public IEncryptionProvider SourceEncryptionProvider { get; }
 
-		/// <summary>
-		/// Returns the new encryption provider, if any.
-		/// </summary>
-		/// <value>
-		/// The new <see cref="IEncryptionProvider"/>, if any.
-		/// </value>
-		public IEncryptionProvider DestinationEncryptionProvider { get; }
+        /// <summary>
+        /// Returns the new encryption provider, if any.
+        /// </summary>
+        /// <value>
+        /// The new <see cref="IEncryptionProvider"/>, if any.
+        /// </value>
+        public IEncryptionProvider DestinationEncryptionProvider { get; }
 
-		/// <summary>
-		/// Returns a flag indicating whether this provider is empty.
-		/// </summary>
-		/// <value>
-		/// <see langword="true"/> if this provider is empty;
-		/// otherwise, <see langword="false"/>.
-		/// </value>
-		public bool IsEmpty => SourceEncryptionProvider is null && DestinationEncryptionProvider is null;
+        /// <summary>
+        /// Returns a flag indicating whether this provider is empty.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if this provider is empty;
+        /// otherwise, <see langword="false"/>.
+        /// </value>
+        public bool IsEmpty => SourceEncryptionProvider is null && DestinationEncryptionProvider is null;
 
-		/// <inheritdoc />
-		public TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter)
-		{
-			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
-			if (converter is null) throw new ArgumentNullException(nameof(converter));
+        /// <inheritdoc />
+        public TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter)
+        {
+            if (decoder is null)
+            {
+                throw new ArgumentNullException(nameof(decoder));
+            }
 
-			if (SourceEncryptionProvider is not null)
-			{
-				return SourceEncryptionProvider.Decrypt(dataToDecrypt, decoder, converter);
-			}
+            if (converter is null)
+            {
+                throw new ArgumentNullException(nameof(converter));
+            }
 
-			byte[] data = decoder(dataToDecrypt);
-			if (data is null || data.Length == 0) return default;
+            if (SourceEncryptionProvider is not null)
+            {
+                return SourceEncryptionProvider.Decrypt(dataToDecrypt, decoder, converter);
+            }
 
-			using var ms = new MemoryStream(data);
-			return converter(ms);
-		}
+            byte[] data = decoder(dataToDecrypt);
+            if (data is null || data.Length == 0)
+            {
+                return default;
+            }
 
-		/// <inheritdoc />
-		public TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder)
-		{
-			if (converter is null) throw new ArgumentNullException(nameof(converter));
-			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
+            using var ms = new MemoryStream(data);
+            return converter(ms);
+        }
 
-			if (DestinationEncryptionProvider is not null)
-			{
-				return DestinationEncryptionProvider.Encrypt(dataToEncrypt, converter, encoder);
-			}
+        /// <inheritdoc />
+        public TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder)
+        {
+            if (converter is null)
+            {
+                throw new ArgumentNullException(nameof(converter));
+            }
 
-			byte[] data = converter(dataToEncrypt);
-			if (data is null || data.Length == 0) return default;
+            if (encoder is null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
 
-			using var ms = new MemoryStream(data);
-			return encoder(ms);
-		}
-	}
+            if (DestinationEncryptionProvider is not null)
+            {
+                return DestinationEncryptionProvider.Encrypt(dataToEncrypt, converter, encoder);
+            }
+
+            byte[] data = converter(dataToEncrypt);
+            if (data is null || data.Length == 0)
+            {
+                return default;
+            }
+
+            using var ms = new MemoryStream(data);
+            return encoder(ms);
+        }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
@@ -1,58 +1,169 @@
 ﻿using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
+using System.Reflection;
+using System.Security;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption
 {
-    /// <summary>
-    /// Provides extensions for the <see cref="ModelBuilder"/>.
-    /// </summary>
-    public static class ModelBuilderExtensions
-    {
-        /// <summary>
-        /// Enables string encryption on this model using an encryption provider.
-        /// </summary>
-        /// <param name="modelBuilder">Current <see cref="ModelBuilder"/> instance.</param>
-        /// <param name="encryptionProvider">Encryption provider.</param>
-        public static void UseEncryption(this ModelBuilder modelBuilder, IEncryptionProvider encryptionProvider)
-        {
-            if (modelBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(modelBuilder), "The given model builder cannot be null");
-            }
+	/// <summary>
+	/// Provides extensions for the <see cref="ModelBuilder"/>.
+	/// </summary>
+	public static class ModelBuilderExtensions
+	{
+		/// <summary>
+		/// Enables encryption on this model using an encryption provider.
+		/// </summary>
+		/// <param name="modelBuilder">
+		/// The <see cref="ModelBuilder"/> instance.
+		/// </param>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/> to use, if any.
+		/// </param>
+		/// <returns>
+		/// The updated <paramref name="modelBuilder"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="modelBuilder"/> is <see langword="null"/>.
+		/// </exception>
+		public static ModelBuilder UseEncryption(this ModelBuilder modelBuilder, IEncryptionProvider encryptionProvider)
+		{
+			if (modelBuilder is null) throw new ArgumentNullException(nameof(modelBuilder));
 
-            if (encryptionProvider is null)
-            {
-                throw new ArgumentNullException(nameof(encryptionProvider), "Cannot initialize encryption with a null provider.");
-            }
+			ValueConverter binaryToBinary = null, binaryToString = null;
+			ValueConverter stringToBinary = null, stringToString = null;
+			ValueConverter secureStringToBinary = null, secureStringToString = null;
+			var secureStringProperties = new List<(Type entityType, string propertyName)>();
 
-            var encryptionConverter = new EncryptionConverter(encryptionProvider);
+			foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+			{
+				foreach (IMutableProperty property in entityType.GetProperties())
+				{
+					var (shouldEncrypt, format) = property.ShouldEncrypt();
+					if (!shouldEncrypt) continue;
 
-            foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
-            {
-                foreach (IMutableProperty property in entityType.GetProperties())
-                {
-                    if (property.ClrType == typeof(string) && !IsDiscriminator(property))
-                    {
-                        object[] attributes = property.PropertyInfo.GetCustomAttributes(typeof(EncryptedAttribute), false);
+					if (property.ClrType == typeof(byte[]))
+					{
+						switch (format)
+						{
+							case StorageFormat.Base64:
+							{
+								binaryToString ??= encryptionProvider.FromBinary().ToBase64().Build();
+								property.SetValueConverter(binaryToString);
+								break;
+							}
+							case StorageFormat.Binary:
+							case StorageFormat.Default:
+							{
+								if (encryptionProvider is not null)
+								{
+									binaryToBinary ??= encryptionProvider.FromBinary().ToBinary().Build();
+									property.SetValueConverter(binaryToBinary);
+								}
+								break;
+							}
+							default:
+							{
+								throw new NotSupportedException($"Storage format {format} is not supported.");
+							}
+						}
+					}
+					else if (property.ClrType == typeof(string))
+					{
+						switch (format)
+						{
+							case StorageFormat.Binary:
+							{
+								stringToBinary ??= encryptionProvider.FromString().ToBinary().Build();
+								property.SetValueConverter(stringToBinary);
+								break;
+							}
+							case StorageFormat.Base64:
+							case StorageFormat.Default:
+							{
+								if (encryptionProvider is not null)
+								{
+									stringToString ??= encryptionProvider.FromString().ToBase64().Build();
+									property.SetValueConverter(stringToString);
+								}
+								break;
+							}
+							default:
+							{
+								throw new NotSupportedException($"Storage format {format} is not supported.");
+							}
+						}
+					}
+					else if (property.ClrType == typeof(SecureString))
+					{
+						switch (format)
+						{
+							case StorageFormat.Base64:
+							{
+								secureStringToString ??= encryptionProvider.FromSecureString().ToBase64().Build();
+								property.SetValueConverter(secureStringToString);
+								break;
+							}
+							case StorageFormat.Binary:
+							case StorageFormat.Default:
+							{
+								secureStringToBinary ??= encryptionProvider.FromSecureString().ToBinary().Build();
+								property.SetValueConverter(secureStringToBinary);
+								break;
+							}
+							default:
+							{
+								throw new NotSupportedException($"Storage format {format} is not supported.");
+							}
+						}
+					}
+				}
 
-                        if (attributes.Any())
-                        {
-                            property.SetValueConverter(encryptionConverter);
-                        }
-                    }
-                }
-            }
-        }
+				// By default, SecureString properties are created as navigation properties, and need to be reconfigured:
+				foreach (var navigation in entityType.GetNavigations())
+				{
+					if (navigation.ClrType == typeof(SecureString))
+					{
+						secureStringProperties.Add((entityType.ClrType, navigation.Name));
+					}
+				}
+			}
 
-        /// <summary>
-        /// Gets a boolean value that indicates if the given property is a descrimitator.
-        /// </summary>
-        /// <param name="property"></param>
-        /// <returns></returns>
-        private static bool IsDiscriminator(IMutableProperty property) 
-            => property.Name == "Discriminator" || property.PropertyInfo == null;
-    }
+			if (secureStringProperties.Count != 0)
+			{
+				foreach (var (entityType, propertyName) in secureStringProperties)
+				{
+					var property = modelBuilder.Entity(entityType).Property(propertyName);
+					var attribute = property.Metadata.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
+					var format = attribute?.Format ?? StorageFormat.Default;
+
+					switch (format)
+					{
+						case StorageFormat.Base64:
+						{
+							secureStringToString ??= encryptionProvider.FromSecureString().ToBase64().Build();
+							property.HasConversion(secureStringToString);
+							break;
+						}
+						case StorageFormat.Binary:
+						case StorageFormat.Default:
+						{
+							secureStringToBinary ??= encryptionProvider.FromSecureString().ToBinary().Build();
+							property.HasConversion(secureStringToBinary);
+							break;
+						}
+						default:
+						{
+							throw new NotSupportedException($"Storage format {format} is not supported.");
+						}
+					}
+				}
+			}
+
+			return modelBuilder;
+		}
+	}
 }

--- a/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelBuilderExtensions.cs
@@ -9,161 +9,167 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption
 {
-	/// <summary>
-	/// Provides extensions for the <see cref="ModelBuilder"/>.
-	/// </summary>
-	public static class ModelBuilderExtensions
-	{
-		/// <summary>
-		/// Enables encryption on this model using an encryption provider.
-		/// </summary>
-		/// <param name="modelBuilder">
-		/// The <see cref="ModelBuilder"/> instance.
-		/// </param>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/> to use, if any.
-		/// </param>
-		/// <returns>
-		/// The updated <paramref name="modelBuilder"/>.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="modelBuilder"/> is <see langword="null"/>.
-		/// </exception>
-		public static ModelBuilder UseEncryption(this ModelBuilder modelBuilder, IEncryptionProvider encryptionProvider)
-		{
-			if (modelBuilder is null) throw new ArgumentNullException(nameof(modelBuilder));
+    /// <summary>
+    /// Provides extensions for the <see cref="ModelBuilder"/>.
+    /// </summary>
+    public static class ModelBuilderExtensions
+    {
+        /// <summary>
+        /// Enables encryption on this model using an encryption provider.
+        /// </summary>
+        /// <param name="modelBuilder">
+        /// The <see cref="ModelBuilder"/> instance.
+        /// </param>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/> to use, if any.
+        /// </param>
+        /// <returns>
+        /// The updated <paramref name="modelBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="modelBuilder"/> is <see langword="null"/>.
+        /// </exception>
+        public static ModelBuilder UseEncryption(this ModelBuilder modelBuilder, IEncryptionProvider encryptionProvider)
+        {
+            if (modelBuilder is null)
+            {
+                throw new ArgumentNullException(nameof(modelBuilder));
+            }
 
-			ValueConverter binaryToBinary = null, binaryToString = null;
-			ValueConverter stringToBinary = null, stringToString = null;
-			ValueConverter secureStringToBinary = null, secureStringToString = null;
-			var secureStringProperties = new List<(Type entityType, string propertyName)>();
+            ValueConverter binaryToBinary = null, binaryToString = null;
+            ValueConverter stringToBinary = null, stringToString = null;
+            ValueConverter secureStringToBinary = null, secureStringToString = null;
+            var secureStringProperties = new List<(Type entityType, string propertyName)>();
 
-			foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
-			{
-				foreach (IMutableProperty property in entityType.GetProperties())
-				{
-					var (shouldEncrypt, format) = property.ShouldEncrypt();
-					if (!shouldEncrypt) continue;
+            foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                foreach (IMutableProperty property in entityType.GetProperties())
+                {
+                    var (shouldEncrypt, format) = property.ShouldEncrypt();
+                    if (!shouldEncrypt)
+                    {
+                        continue;
+                    }
 
-					if (property.ClrType == typeof(byte[]))
-					{
-						switch (format)
-						{
-							case StorageFormat.Base64:
-							{
-								binaryToString ??= encryptionProvider.FromBinary().ToBase64().Build();
-								property.SetValueConverter(binaryToString);
-								break;
-							}
-							case StorageFormat.Binary:
-							case StorageFormat.Default:
-							{
-								if (encryptionProvider is not null)
-								{
-									binaryToBinary ??= encryptionProvider.FromBinary().ToBinary().Build();
-									property.SetValueConverter(binaryToBinary);
-								}
-								break;
-							}
-							default:
-							{
-								throw new NotSupportedException($"Storage format {format} is not supported.");
-							}
-						}
-					}
-					else if (property.ClrType == typeof(string))
-					{
-						switch (format)
-						{
-							case StorageFormat.Binary:
-							{
-								stringToBinary ??= encryptionProvider.FromString().ToBinary().Build();
-								property.SetValueConverter(stringToBinary);
-								break;
-							}
-							case StorageFormat.Base64:
-							case StorageFormat.Default:
-							{
-								if (encryptionProvider is not null)
-								{
-									stringToString ??= encryptionProvider.FromString().ToBase64().Build();
-									property.SetValueConverter(stringToString);
-								}
-								break;
-							}
-							default:
-							{
-								throw new NotSupportedException($"Storage format {format} is not supported.");
-							}
-						}
-					}
-					else if (property.ClrType == typeof(SecureString))
-					{
-						switch (format)
-						{
-							case StorageFormat.Base64:
-							{
-								secureStringToString ??= encryptionProvider.FromSecureString().ToBase64().Build();
-								property.SetValueConverter(secureStringToString);
-								break;
-							}
-							case StorageFormat.Binary:
-							case StorageFormat.Default:
-							{
-								secureStringToBinary ??= encryptionProvider.FromSecureString().ToBinary().Build();
-								property.SetValueConverter(secureStringToBinary);
-								break;
-							}
-							default:
-							{
-								throw new NotSupportedException($"Storage format {format} is not supported.");
-							}
-						}
-					}
-				}
+                    if (property.ClrType == typeof(byte[]))
+                    {
+                        switch (format)
+                        {
+                            case StorageFormat.Base64:
+                            {
+                                binaryToString ??= encryptionProvider.FromBinary().ToBase64().Build();
+                                property.SetValueConverter(binaryToString);
+                                break;
+                            }
+                            case StorageFormat.Binary:
+                            case StorageFormat.Default:
+                            {
+                                if (encryptionProvider is not null)
+                                {
+                                    binaryToBinary ??= encryptionProvider.FromBinary().ToBinary().Build();
+                                    property.SetValueConverter(binaryToBinary);
+                                }
+                                break;
+                            }
+                            default:
+                            {
+                                throw new NotSupportedException($"Storage format {format} is not supported.");
+                            }
+                        }
+                    }
+                    else if (property.ClrType == typeof(string))
+                    {
+                        switch (format)
+                        {
+                            case StorageFormat.Binary:
+                            {
+                                stringToBinary ??= encryptionProvider.FromString().ToBinary().Build();
+                                property.SetValueConverter(stringToBinary);
+                                break;
+                            }
+                            case StorageFormat.Base64:
+                            case StorageFormat.Default:
+                            {
+                                if (encryptionProvider is not null)
+                                {
+                                    stringToString ??= encryptionProvider.FromString().ToBase64().Build();
+                                    property.SetValueConverter(stringToString);
+                                }
+                                break;
+                            }
+                            default:
+                            {
+                                throw new NotSupportedException($"Storage format {format} is not supported.");
+                            }
+                        }
+                    }
+                    else if (property.ClrType == typeof(SecureString))
+                    {
+                        switch (format)
+                        {
+                            case StorageFormat.Base64:
+                            {
+                                secureStringToString ??= encryptionProvider.FromSecureString().ToBase64().Build();
+                                property.SetValueConverter(secureStringToString);
+                                break;
+                            }
+                            case StorageFormat.Binary:
+                            case StorageFormat.Default:
+                            {
+                                secureStringToBinary ??= encryptionProvider.FromSecureString().ToBinary().Build();
+                                property.SetValueConverter(secureStringToBinary);
+                                break;
+                            }
+                            default:
+                            {
+                                throw new NotSupportedException($"Storage format {format} is not supported.");
+                            }
+                        }
+                    }
+                }
 
-				// By default, SecureString properties are created as navigation properties, and need to be reconfigured:
-				foreach (var navigation in entityType.GetNavigations())
-				{
-					if (navigation.ClrType == typeof(SecureString))
-					{
-						secureStringProperties.Add((entityType.ClrType, navigation.Name));
-					}
-				}
-			}
+                // By default, SecureString properties are created as navigation properties, and need to be reconfigured:
+                foreach (var navigation in entityType.GetNavigations())
+                {
+                    if (navigation.ClrType == typeof(SecureString))
+                    {
+                        secureStringProperties.Add((entityType.ClrType, navigation.Name));
+                    }
+                }
+            }
 
-			if (secureStringProperties.Count != 0)
-			{
-				foreach (var (entityType, propertyName) in secureStringProperties)
-				{
-					var property = modelBuilder.Entity(entityType).Property(propertyName);
-					var attribute = property.Metadata.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
-					var format = attribute?.Format ?? StorageFormat.Default;
+            if (secureStringProperties.Count != 0)
+            {
+                foreach (var (entityType, propertyName) in secureStringProperties)
+                {
+                    var property = modelBuilder.Entity(entityType).Property(propertyName);
+                    var attribute = property.Metadata.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
+                    var format = attribute?.Format ?? StorageFormat.Default;
 
-					switch (format)
-					{
-						case StorageFormat.Base64:
-						{
-							secureStringToString ??= encryptionProvider.FromSecureString().ToBase64().Build();
-							property.HasConversion(secureStringToString);
-							break;
-						}
-						case StorageFormat.Binary:
-						case StorageFormat.Default:
-						{
-							secureStringToBinary ??= encryptionProvider.FromSecureString().ToBinary().Build();
-							property.HasConversion(secureStringToBinary);
-							break;
-						}
-						default:
-						{
-							throw new NotSupportedException($"Storage format {format} is not supported.");
-						}
-					}
-				}
-			}
+                    switch (format)
+                    {
+                        case StorageFormat.Base64:
+                        {
+                            secureStringToString ??= encryptionProvider.FromSecureString().ToBase64().Build();
+                            property.HasConversion(secureStringToString);
+                            break;
+                        }
+                        case StorageFormat.Binary:
+                        case StorageFormat.Default:
+                        {
+                            secureStringToBinary ??= encryptionProvider.FromSecureString().ToBinary().Build();
+                            property.HasConversion(secureStringToBinary);
+                            break;
+                        }
+                        default:
+                        {
+                            throw new NotSupportedException($"Storage format {format} is not supported.");
+                        }
+                    }
+                }
+            }
 
-			return modelBuilder;
-		}
-	}
+            return modelBuilder;
+        }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/ModelExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelExtensions.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using System.Security;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption
+{
+	/// <summary>
+	/// Extension methods for EF models.
+	/// </summary>
+	public static class ModelExtensions
+	{
+		/// <summary>
+		/// Returns a value indicating whether the specified property should be encrypted.
+		/// </summary>
+		/// <param name="property">
+		/// The <see cref="IProperty"/>.
+		/// </param>
+		/// <returns>
+		/// A value indicating whether the specified property should be encrypted,
+		/// and how the encrypted value should be stored.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="property"/> is <see langword="null"/>.
+		/// </exception>
+		public static (bool shouldEncrypt, StorageFormat format) ShouldEncrypt(this IProperty property)
+		{
+			if (property is null) throw new ArgumentNullException(nameof(property));
+
+			var attribute = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
+			if (property.ClrType == typeof(SecureString)) return (true, attribute?.Format ?? StorageFormat.Binary);
+			return attribute is null ? (false, StorageFormat.Default) : (true, attribute.Format);
+		}
+
+		/// <summary>
+		/// Returns a value indicating whether the specified property should be encrypted.
+		/// </summary>
+		/// <param name="property">
+		/// The <see cref="IMutableProperty"/>.
+		/// </param>
+		/// <returns>
+		/// A value indicating whether the specified property should be encrypted,
+		/// and how the encrypted value should be stored.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="property"/> is <see langword="null"/>.
+		/// </exception>
+		public static (bool shouldEncrypt, StorageFormat format) ShouldEncrypt(this IMutableProperty property)
+		{
+			if (property is null) throw new ArgumentNullException(nameof(property));
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+			if (property.FindAnnotation(CoreAnnotationNames.ValueConverter) is not null) return (false, StorageFormat.Default);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+			var attribute = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
+			if (property.ClrType == typeof(SecureString)) return (true, attribute?.Format ?? StorageFormat.Binary);
+			return attribute is null ? (false, StorageFormat.Default) : (true, attribute.Format);
+		}
+
+		/// <summary>
+		/// Returns the list of encrypted properties for the specified entity type.
+		/// </summary>
+		/// <param name="entityType">
+		/// The <see cref="IEntityType"/>.
+		/// </param>
+		/// <returns>
+		/// A list of the properties for the specified type which should be encrypted.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="entityType"/> is <see langword="null"/>.
+		/// </exception>
+		public static IReadOnlyList<(IProperty property, StorageFormat format)> ListEncryptedProperties(this IEntityType entityType)
+		{
+			if (entityType is null) throw new ArgumentNullException(nameof(entityType));
+
+			return entityType.GetProperties()
+				.Select(p => (property: p, flag: p.ShouldEncrypt()))
+				.Where(p => p.flag.shouldEncrypt)
+				.Select(p => (p.property, p.flag.format)).ToList();
+		}
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/ModelExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/ModelExtensions.cs
@@ -9,79 +9,99 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption
 {
-	/// <summary>
-	/// Extension methods for EF models.
-	/// </summary>
-	public static class ModelExtensions
-	{
-		/// <summary>
-		/// Returns a value indicating whether the specified property should be encrypted.
-		/// </summary>
-		/// <param name="property">
-		/// The <see cref="IProperty"/>.
-		/// </param>
-		/// <returns>
-		/// A value indicating whether the specified property should be encrypted,
-		/// and how the encrypted value should be stored.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="property"/> is <see langword="null"/>.
-		/// </exception>
-		public static (bool shouldEncrypt, StorageFormat format) ShouldEncrypt(this IProperty property)
-		{
-			if (property is null) throw new ArgumentNullException(nameof(property));
+    /// <summary>
+    /// Extension methods for EF models.
+    /// </summary>
+    public static class ModelExtensions
+    {
+        /// <summary>
+        /// Returns a value indicating whether the specified property should be encrypted.
+        /// </summary>
+        /// <param name="property">
+        /// The <see cref="IProperty"/>.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether the specified property should be encrypted,
+        /// and how the encrypted value should be stored.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        public static (bool shouldEncrypt, StorageFormat format) ShouldEncrypt(this IProperty property)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
-			var attribute = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
-			if (property.ClrType == typeof(SecureString)) return (true, attribute?.Format ?? StorageFormat.Binary);
-			return attribute is null ? (false, StorageFormat.Default) : (true, attribute.Format);
-		}
+            var attribute = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
+            if (property.ClrType == typeof(SecureString))
+            {
+                return (true, attribute?.Format ?? StorageFormat.Binary);
+            }
 
-		/// <summary>
-		/// Returns a value indicating whether the specified property should be encrypted.
-		/// </summary>
-		/// <param name="property">
-		/// The <see cref="IMutableProperty"/>.
-		/// </param>
-		/// <returns>
-		/// A value indicating whether the specified property should be encrypted,
-		/// and how the encrypted value should be stored.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="property"/> is <see langword="null"/>.
-		/// </exception>
-		public static (bool shouldEncrypt, StorageFormat format) ShouldEncrypt(this IMutableProperty property)
-		{
-			if (property is null) throw new ArgumentNullException(nameof(property));
+            return attribute is null ? (false, StorageFormat.Default) : (true, attribute.Format);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the specified property should be encrypted.
+        /// </summary>
+        /// <param name="property">
+        /// The <see cref="IMutableProperty"/>.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether the specified property should be encrypted,
+        /// and how the encrypted value should be stored.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        public static (bool shouldEncrypt, StorageFormat format) ShouldEncrypt(this IMutableProperty property)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
-			if (property.FindAnnotation(CoreAnnotationNames.ValueConverter) is not null) return (false, StorageFormat.Default);
+            if (property.FindAnnotation(CoreAnnotationNames.ValueConverter) is not null)
+            {
+                return (false, StorageFormat.Default);
+            }
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
-			var attribute = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
-			if (property.ClrType == typeof(SecureString)) return (true, attribute?.Format ?? StorageFormat.Binary);
-			return attribute is null ? (false, StorageFormat.Default) : (true, attribute.Format);
-		}
+            var attribute = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>(false);
+            if (property.ClrType == typeof(SecureString))
+            {
+                return (true, attribute?.Format ?? StorageFormat.Binary);
+            }
 
-		/// <summary>
-		/// Returns the list of encrypted properties for the specified entity type.
-		/// </summary>
-		/// <param name="entityType">
-		/// The <see cref="IEntityType"/>.
-		/// </param>
-		/// <returns>
-		/// A list of the properties for the specified type which should be encrypted.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="entityType"/> is <see langword="null"/>.
-		/// </exception>
-		public static IReadOnlyList<(IProperty property, StorageFormat format)> ListEncryptedProperties(this IEntityType entityType)
-		{
-			if (entityType is null) throw new ArgumentNullException(nameof(entityType));
+            return attribute is null ? (false, StorageFormat.Default) : (true, attribute.Format);
+        }
 
-			return entityType.GetProperties()
-				.Select(p => (property: p, flag: p.ShouldEncrypt()))
-				.Where(p => p.flag.shouldEncrypt)
-				.Select(p => (p.property, p.flag.format)).ToList();
-		}
-	}
+        /// <summary>
+        /// Returns the list of encrypted properties for the specified entity type.
+        /// </summary>
+        /// <param name="entityType">
+        /// The <see cref="IEntityType"/>.
+        /// </param>
+        /// <returns>
+        /// A list of the properties for the specified type which should be encrypted.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="entityType"/> is <see langword="null"/>.
+        /// </exception>
+        public static IReadOnlyList<(IProperty property, StorageFormat format)> ListEncryptedProperties(this IEntityType entityType)
+        {
+            if (entityType is null)
+            {
+                throw new ArgumentNullException(nameof(entityType));
+            }
+
+            return entityType.GetProperties()
+                .Select(p => (property: p, flag: p.ShouldEncrypt()))
+                .Where(p => p.flag.shouldEncrypt)
+                .Select(p => (p.property, p.flag.format)).ToList();
+        }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/PropertyBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/PropertyBuilderExtensions.cs
@@ -7,132 +7,141 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption
 {
-	/// <summary>
-	/// Provides extensions for the <see cref="PropertyBuilder"/>.
-	/// </summary>
-	public static class PropertyBuilderExtensions
-	{
-		/// <summary>
-		/// Configures the property as capable of storing encrypted data.
-		/// </summary>
-		/// <param name="property">
-		/// The <see cref="PropertyBuilder{TProperty}"/>.
-		/// </param>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/> to use, if any.
-		/// </param>
-		/// <param name="format">
-		/// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
-		/// </param>
-		/// <param name="mappingHints">
-		/// The <see cref="ConverterMappingHints"/> to use, if any.
-		/// </param>
-		/// <returns>
-		/// The updated <see cref="PropertyBuilder{TProperty}"/>.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="property"/> is <see langword="null"/>.
-		/// </exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// <paramref name="format"/> is not a recognised value.
-		/// </exception>
-		public static PropertyBuilder<byte[]> IsEncrypted(
-			this PropertyBuilder<byte[]> property,
-			IEncryptionProvider encryptionProvider,
-			StorageFormat format = StorageFormat.Default,
-			ConverterMappingHints mappingHints = null)
-		{
-			if (property is null) throw new ArgumentNullException(nameof(property));
+    /// <summary>
+    /// Provides extensions for the <see cref="PropertyBuilder"/>.
+    /// </summary>
+    public static class PropertyBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the property as capable of storing encrypted data.
+        /// </summary>
+        /// <param name="property">
+        /// The <see cref="PropertyBuilder{TProperty}"/>.
+        /// </param>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/> to use, if any.
+        /// </param>
+        /// <param name="format">
+        /// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
+        /// </param>
+        /// <param name="mappingHints">
+        /// The <see cref="ConverterMappingHints"/> to use, if any.
+        /// </param>
+        /// <returns>
+        /// The updated <see cref="PropertyBuilder{TProperty}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="format"/> is not a recognised value.
+        /// </exception>
+        public static PropertyBuilder<byte[]> IsEncrypted(
+            this PropertyBuilder<byte[]> property,
+            IEncryptionProvider encryptionProvider,
+            StorageFormat format = StorageFormat.Default,
+            ConverterMappingHints mappingHints = null)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
-			return format switch
-			{
-				StorageFormat.Default => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromBinary().ToBinary().Build(mappingHints)),
-				StorageFormat.Binary => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromBinary().ToBinary().Build(mappingHints)),
-				StorageFormat.Base64 => property.HasConversion(encryptionProvider.FromBinary().ToBase64().Build(mappingHints)),
-				_ => throw new ArgumentOutOfRangeException(nameof(format)),
-			};
-		}
+            return format switch
+            {
+                StorageFormat.Default => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromBinary().ToBinary().Build(mappingHints)),
+                StorageFormat.Binary => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromBinary().ToBinary().Build(mappingHints)),
+                StorageFormat.Base64 => property.HasConversion(encryptionProvider.FromBinary().ToBase64().Build(mappingHints)),
+                _ => throw new ArgumentOutOfRangeException(nameof(format)),
+            };
+        }
 
-		/// <summary>
-		/// Configures the property as capable of storing encrypted data.
-		/// </summary>
-		/// <param name="property">
-		/// The <see cref="PropertyBuilder{TProperty}"/>.
-		/// </param>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/> to use, if any.
-		/// </param>
-		/// <param name="format">
-		/// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
-		/// </param>
-		/// <param name="mappingHints">
-		/// The <see cref="ConverterMappingHints"/> to use, if any.
-		/// </param>
-		/// <returns>
-		/// The updated <see cref="PropertyBuilder{TProperty}"/>.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="property"/> is <see langword="null"/>.
-		/// </exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// <paramref name="format"/> is not a recognised value.
-		/// </exception>
-		public static PropertyBuilder<string> IsEncrypted(
-			this PropertyBuilder<string> property,
-			IEncryptionProvider encryptionProvider,
-			StorageFormat format = StorageFormat.Default,
-			ConverterMappingHints mappingHints = null)
-		{
-			if (property is null) throw new ArgumentNullException(nameof(property));
+        /// <summary>
+        /// Configures the property as capable of storing encrypted data.
+        /// </summary>
+        /// <param name="property">
+        /// The <see cref="PropertyBuilder{TProperty}"/>.
+        /// </param>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/> to use, if any.
+        /// </param>
+        /// <param name="format">
+        /// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
+        /// </param>
+        /// <param name="mappingHints">
+        /// The <see cref="ConverterMappingHints"/> to use, if any.
+        /// </param>
+        /// <returns>
+        /// The updated <see cref="PropertyBuilder{TProperty}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="format"/> is not a recognised value.
+        /// </exception>
+        public static PropertyBuilder<string> IsEncrypted(
+            this PropertyBuilder<string> property,
+            IEncryptionProvider encryptionProvider,
+            StorageFormat format = StorageFormat.Default,
+            ConverterMappingHints mappingHints = null)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
-			return format switch
-			{
-				StorageFormat.Default => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromString().ToBase64().Build(mappingHints)),
-				StorageFormat.Base64 => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromString().ToBase64().Build(mappingHints)),
-				StorageFormat.Binary => property.HasConversion(encryptionProvider.FromString().ToBinary().Build(mappingHints)),
-				_ => throw new ArgumentOutOfRangeException(nameof(format)),
-			};
-		}
+            return format switch
+            {
+                StorageFormat.Default => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromString().ToBase64().Build(mappingHints)),
+                StorageFormat.Base64 => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromString().ToBase64().Build(mappingHints)),
+                StorageFormat.Binary => property.HasConversion(encryptionProvider.FromString().ToBinary().Build(mappingHints)),
+                _ => throw new ArgumentOutOfRangeException(nameof(format)),
+            };
+        }
 
-		/// <summary>
-		/// Configures the property as capable of storing encrypted data.
-		/// </summary>
-		/// <param name="property">
-		/// The <see cref="PropertyBuilder{TProperty}"/>.
-		/// </param>
-		/// <param name="encryptionProvider">
-		/// The <see cref="IEncryptionProvider"/> to use, if any.
-		/// </param>
-		/// <param name="format">
-		/// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
-		/// </param>
-		/// <param name="mappingHints">
-		/// The <see cref="ConverterMappingHints"/> to use, if any.
-		/// </param>
-		/// <returns>
-		/// The updated <see cref="PropertyBuilder{TProperty}"/>.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="property"/> is <see langword="null"/>.
-		/// </exception>
-		/// <exception cref="ArgumentOutOfRangeException">
-		/// <paramref name="format"/> is not a recognised value.
-		/// </exception>
-		public static PropertyBuilder<SecureString> IsEncrypted(
-			this PropertyBuilder<SecureString> property,
-			IEncryptionProvider encryptionProvider,
-			StorageFormat format = StorageFormat.Default,
-			ConverterMappingHints mappingHints = null)
-		{
-			if (property is null) throw new ArgumentNullException(nameof(property));
+        /// <summary>
+        /// Configures the property as capable of storing encrypted data.
+        /// </summary>
+        /// <param name="property">
+        /// The <see cref="PropertyBuilder{TProperty}"/>.
+        /// </param>
+        /// <param name="encryptionProvider">
+        /// The <see cref="IEncryptionProvider"/> to use, if any.
+        /// </param>
+        /// <param name="format">
+        /// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
+        /// </param>
+        /// <param name="mappingHints">
+        /// The <see cref="ConverterMappingHints"/> to use, if any.
+        /// </param>
+        /// <returns>
+        /// The updated <see cref="PropertyBuilder{TProperty}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="format"/> is not a recognised value.
+        /// </exception>
+        public static PropertyBuilder<SecureString> IsEncrypted(
+            this PropertyBuilder<SecureString> property,
+            IEncryptionProvider encryptionProvider,
+            StorageFormat format = StorageFormat.Default,
+            ConverterMappingHints mappingHints = null)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
-			return format switch
-			{
-				StorageFormat.Default => property.HasConversion(encryptionProvider.FromSecureString().ToBinary().Build(mappingHints)),
-				StorageFormat.Binary => property.HasConversion(encryptionProvider.FromSecureString().ToBinary().Build(mappingHints)),
-				StorageFormat.Base64 => property.HasConversion(encryptionProvider.FromSecureString().ToBase64().Build(mappingHints)),
-				_ => throw new ArgumentOutOfRangeException(nameof(format)),
-			};
-		}
-	}
+            return format switch
+            {
+                StorageFormat.Default => property.HasConversion(encryptionProvider.FromSecureString().ToBinary().Build(mappingHints)),
+                StorageFormat.Binary => property.HasConversion(encryptionProvider.FromSecureString().ToBinary().Build(mappingHints)),
+                StorageFormat.Base64 => property.HasConversion(encryptionProvider.FromSecureString().ToBase64().Build(mappingHints)),
+                _ => throw new ArgumentOutOfRangeException(nameof(format)),
+            };
+        }
+    }
 }

--- a/src/EntityFrameworkCore.DataEncryption/PropertyBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DataEncryption/PropertyBuilderExtensions.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Security;
+using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Microsoft.EntityFrameworkCore.DataEncryption
+{
+	/// <summary>
+	/// Provides extensions for the <see cref="PropertyBuilder"/>.
+	/// </summary>
+	public static class PropertyBuilderExtensions
+	{
+		/// <summary>
+		/// Configures the property as capable of storing encrypted data.
+		/// </summary>
+		/// <param name="property">
+		/// The <see cref="PropertyBuilder{TProperty}"/>.
+		/// </param>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/> to use, if any.
+		/// </param>
+		/// <param name="format">
+		/// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
+		/// </param>
+		/// <param name="mappingHints">
+		/// The <see cref="ConverterMappingHints"/> to use, if any.
+		/// </param>
+		/// <returns>
+		/// The updated <see cref="PropertyBuilder{TProperty}"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="property"/> is <see langword="null"/>.
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="format"/> is not a recognised value.
+		/// </exception>
+		public static PropertyBuilder<byte[]> IsEncrypted(
+			this PropertyBuilder<byte[]> property,
+			IEncryptionProvider encryptionProvider,
+			StorageFormat format = StorageFormat.Default,
+			ConverterMappingHints mappingHints = null)
+		{
+			if (property is null) throw new ArgumentNullException(nameof(property));
+
+			return format switch
+			{
+				StorageFormat.Default => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromBinary().ToBinary().Build(mappingHints)),
+				StorageFormat.Binary => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromBinary().ToBinary().Build(mappingHints)),
+				StorageFormat.Base64 => property.HasConversion(encryptionProvider.FromBinary().ToBase64().Build(mappingHints)),
+				_ => throw new ArgumentOutOfRangeException(nameof(format)),
+			};
+		}
+
+		/// <summary>
+		/// Configures the property as capable of storing encrypted data.
+		/// </summary>
+		/// <param name="property">
+		/// The <see cref="PropertyBuilder{TProperty}"/>.
+		/// </param>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/> to use, if any.
+		/// </param>
+		/// <param name="format">
+		/// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
+		/// </param>
+		/// <param name="mappingHints">
+		/// The <see cref="ConverterMappingHints"/> to use, if any.
+		/// </param>
+		/// <returns>
+		/// The updated <see cref="PropertyBuilder{TProperty}"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="property"/> is <see langword="null"/>.
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="format"/> is not a recognised value.
+		/// </exception>
+		public static PropertyBuilder<string> IsEncrypted(
+			this PropertyBuilder<string> property,
+			IEncryptionProvider encryptionProvider,
+			StorageFormat format = StorageFormat.Default,
+			ConverterMappingHints mappingHints = null)
+		{
+			if (property is null) throw new ArgumentNullException(nameof(property));
+
+			return format switch
+			{
+				StorageFormat.Default => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromString().ToBase64().Build(mappingHints)),
+				StorageFormat.Base64 => encryptionProvider is null ? property : property.HasConversion(encryptionProvider.FromString().ToBase64().Build(mappingHints)),
+				StorageFormat.Binary => property.HasConversion(encryptionProvider.FromString().ToBinary().Build(mappingHints)),
+				_ => throw new ArgumentOutOfRangeException(nameof(format)),
+			};
+		}
+
+		/// <summary>
+		/// Configures the property as capable of storing encrypted data.
+		/// </summary>
+		/// <param name="property">
+		/// The <see cref="PropertyBuilder{TProperty}"/>.
+		/// </param>
+		/// <param name="encryptionProvider">
+		/// The <see cref="IEncryptionProvider"/> to use, if any.
+		/// </param>
+		/// <param name="format">
+		/// One of the <see cref="StorageFormat"/> values indicating how the value should be stored in the database.
+		/// </param>
+		/// <param name="mappingHints">
+		/// The <see cref="ConverterMappingHints"/> to use, if any.
+		/// </param>
+		/// <returns>
+		/// The updated <see cref="PropertyBuilder{TProperty}"/>.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="property"/> is <see langword="null"/>.
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="format"/> is not a recognised value.
+		/// </exception>
+		public static PropertyBuilder<SecureString> IsEncrypted(
+			this PropertyBuilder<SecureString> property,
+			IEncryptionProvider encryptionProvider,
+			StorageFormat format = StorageFormat.Default,
+			ConverterMappingHints mappingHints = null)
+		{
+			if (property is null) throw new ArgumentNullException(nameof(property));
+
+			return format switch
+			{
+				StorageFormat.Default => property.HasConversion(encryptionProvider.FromSecureString().ToBinary().Build(mappingHints)),
+				StorageFormat.Binary => property.HasConversion(encryptionProvider.FromSecureString().ToBinary().Build(mappingHints)),
+				StorageFormat.Base64 => property.HasConversion(encryptionProvider.FromSecureString().ToBase64().Build(mappingHints)),
+				_ => throw new ArgumentOutOfRangeException(nameof(format)),
+			};
+		}
+	}
+}

--- a/src/EntityFrameworkCore.DataEncryption/Providers/AesProvider.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Providers/AesProvider.cs
@@ -4,143 +4,163 @@ using System.Security.Cryptography;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Providers
 {
-	/// <summary>
-	/// Implements the Advanced Encryption Standard (AES) symmetric algorithm.
-	/// </summary>
-	public class AesProvider : IEncryptionProvider
-	{
-		/// <summary>
-		/// AES block size constant.
-		/// </summary>
-		public const int AesBlockSize = 128;
+    /// <summary>
+    /// Implements the Advanced Encryption Standard (AES) symmetric algorithm.
+    /// </summary>
+    public class AesProvider : IEncryptionProvider
+    {
+        /// <summary>
+        /// AES block size constant.
+        /// </summary>
+        public const int AesBlockSize = 128;
 
-		/// <summary>
-		/// Initialization vector size constant.
-		/// </summary>
-		public const int InitializationVectorSize = 16;
+        /// <summary>
+        /// Initialization vector size constant.
+        /// </summary>
+        public const int InitializationVectorSize = 16;
 
-		private readonly byte[] _key;
-		private readonly CipherMode _mode;
-		private readonly PaddingMode _padding;
-		private readonly byte[] _iv;
+        private readonly byte[] _key;
+        private readonly CipherMode _mode;
+        private readonly PaddingMode _padding;
+        private readonly byte[] _iv;
 
-		/// <summary>
-		/// Creates a new <see cref="AesProvider"/> instance used to perform symmetric encryption and decryption on strings.
-		/// </summary>
-		/// <param name="key">AES key used for the symmetric encryption.</param>
-		/// <param name="mode">Mode for operation used in the symmetric encryption.</param>
-		/// <param name="padding">Padding mode used in the symmetric encryption.</param>
-		public AesProvider(byte[] key, CipherMode mode = CipherMode.CBC, PaddingMode padding = PaddingMode.PKCS7)
-		{
-			_key = key;
-			_mode = mode;
-			_padding = padding;
-		}
+        /// <summary>
+        /// Creates a new <see cref="AesProvider"/> instance used to perform symmetric encryption and decryption on strings.
+        /// </summary>
+        /// <param name="key">AES key used for the symmetric encryption.</param>
+        /// <param name="mode">Mode for operation used in the symmetric encryption.</param>
+        /// <param name="padding">Padding mode used in the symmetric encryption.</param>
+        public AesProvider(byte[] key, CipherMode mode = CipherMode.CBC, PaddingMode padding = PaddingMode.PKCS7)
+        {
+            _key = key;
+            _mode = mode;
+            _padding = padding;
+        }
 
-		/// <summary>
-		/// Creates a new <see cref="AesProvider"/> instance used to perform symmetric encryption and decryption on strings.
-		/// </summary>
-		/// <param name="key">AES key used for the symmetric encryption.</param>
-		/// <param name="initializationVector">AES Initialization Vector used for the symmetric encryption.</param>
-		/// <param name="mode">Mode for operation used in the symmetric encryption.</param>
-		/// <param name="padding">Padding mode used in the symmetric encryption.</param>
-		public AesProvider(byte[] key, byte[] initializationVector, CipherMode mode = CipherMode.CBC, PaddingMode padding = PaddingMode.PKCS7) : this(key, mode, padding)
-		{
-			// Re-enabled to allow for a static IV.
-			// This reduces security, but allows for encrypted values to be searched using LINQ.
-			_iv = initializationVector;
-		}
+        /// <summary>
+        /// Creates a new <see cref="AesProvider"/> instance used to perform symmetric encryption and decryption on strings.
+        /// </summary>
+        /// <param name="key">AES key used for the symmetric encryption.</param>
+        /// <param name="initializationVector">AES Initialization Vector used for the symmetric encryption.</param>
+        /// <param name="mode">Mode for operation used in the symmetric encryption.</param>
+        /// <param name="padding">Padding mode used in the symmetric encryption.</param>
+        public AesProvider(byte[] key, byte[] initializationVector, CipherMode mode = CipherMode.CBC, PaddingMode padding = PaddingMode.PKCS7) : this(key, mode, padding)
+        {
+            // Re-enabled to allow for a static IV.
+            // This reduces security, but allows for encrypted values to be searched using LINQ.
+            _iv = initializationVector;
+        }
 
-		/// <inheritdoc />
-		public TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder)
-		{
-			if (converter is null) throw new ArgumentNullException(nameof(converter));
-			if (encoder is null) throw new ArgumentNullException(nameof(encoder));
+        /// <inheritdoc />
+        public TStore Encrypt<TStore, TModel>(TModel dataToEncrypt, Func<TModel, byte[]> converter, Func<Stream, TStore> encoder)
+        {
+            if (converter is null)
+            {
+                throw new ArgumentNullException(nameof(converter));
+            }
 
-			byte[] data = converter(dataToEncrypt);
-			if (data is null || data.Length == 0) return default;
+            if (encoder is null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
 
-			using var aes = CreateCryptographyProvider();
-			using var memoryStream = new MemoryStream();
+            byte[] data = converter(dataToEncrypt);
+            if (data is null || data.Length == 0)
+            {
+                return default;
+            }
 
-			byte[] initializationVector = _iv;
-			if (initializationVector is null)
-			{
-				aes.GenerateIV();
-				initializationVector = aes.IV;
-				memoryStream.Write(initializationVector, 0, initializationVector.Length);
-			}
+            using var aes = CreateCryptographyProvider();
+            using var memoryStream = new MemoryStream();
 
-			using var transform = aes.CreateEncryptor(_key, initializationVector);
-			using var crypto = new CryptoStream(memoryStream, transform, CryptoStreamMode.Write);
-			crypto.Write(data, 0, data.Length);
-			crypto.FlushFinalBlock();
+            byte[] initializationVector = _iv;
+            if (initializationVector is null)
+            {
+                aes.GenerateIV();
+                initializationVector = aes.IV;
+                memoryStream.Write(initializationVector, 0, initializationVector.Length);
+            }
 
-			memoryStream.Seek(0L, SeekOrigin.Begin);
-			return encoder(memoryStream);
-		}
+            using var transform = aes.CreateEncryptor(_key, initializationVector);
+            using var crypto = new CryptoStream(memoryStream, transform, CryptoStreamMode.Write);
+            crypto.Write(data, 0, data.Length);
+            crypto.FlushFinalBlock();
 
-		/// <inheritdoc />
-		public TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter)
-		{
-			if (decoder is null) throw new ArgumentNullException(nameof(decoder));
-			if (converter is null) throw new ArgumentNullException(nameof(converter));
+            memoryStream.Seek(0L, SeekOrigin.Begin);
+            return encoder(memoryStream);
+        }
 
-			byte[] data = decoder(dataToDecrypt);
-			if (data is null || data.Length == 0) return default;
+        /// <inheritdoc />
+        public TModel Decrypt<TStore, TModel>(TStore dataToDecrypt, Func<TStore, byte[]> decoder, Func<Stream, TModel> converter)
+        {
+            if (decoder is null)
+            {
+                throw new ArgumentNullException(nameof(decoder));
+            }
 
-			using var memoryStream = new MemoryStream(data);
+            if (converter is null)
+            {
+                throw new ArgumentNullException(nameof(converter));
+            }
 
-			byte[] initializationVector = _iv;
-			if (initializationVector is null)
-			{
-				initializationVector = new byte[InitializationVectorSize];
-				memoryStream.Read(initializationVector, 0, initializationVector.Length);
-			}
+            byte[] data = decoder(dataToDecrypt);
+            if (data is null || data.Length == 0)
+            {
+                return default;
+            }
 
-			using var aes = CreateCryptographyProvider();
-			using var transform = aes.CreateDecryptor(_key, initializationVector);
-			using var crypto = new CryptoStream(memoryStream, transform, CryptoStreamMode.Read);
-			return converter(crypto);
-		}
+            using var memoryStream = new MemoryStream(data);
 
-		/// <summary>
-		/// Generates an AES cryptography provider.
-		/// </summary>
-		/// <returns></returns>
-		private AesCryptoServiceProvider CreateCryptographyProvider()
-		{
-			return new AesCryptoServiceProvider
-			{
-				BlockSize = AesBlockSize,
-				Mode = _mode,
-				Padding = _padding,
-				Key = _key,
-				KeySize = _key.Length * 8
-			};
-		}
+            byte[] initializationVector = _iv;
+            if (initializationVector is null)
+            {
+                initializationVector = new byte[InitializationVectorSize];
+                memoryStream.Read(initializationVector, 0, initializationVector.Length);
+            }
 
-		/// <summary>
-		/// Generates an AES key.
-		/// </summary>
-		/// <remarks>
-		/// The key size of the Aes encryption must be 128, 192 or 256 bits. 
-		/// Please check https://blogs.msdn.microsoft.com/shawnfa/2006/10/09/the-differences-between-rijndael-and-aes/ for more informations.
-		/// </remarks>
-		/// <param name="keySize">AES Key size</param>
-		/// <returns></returns>
-		public static AesKeyInfo GenerateKey(AesKeySize keySize)
-		{
-			var crypto = new AesCryptoServiceProvider
-			{
-				KeySize = (int)keySize,
-				BlockSize = AesBlockSize
-			};
+            using var aes = CreateCryptographyProvider();
+            using var transform = aes.CreateDecryptor(_key, initializationVector);
+            using var crypto = new CryptoStream(memoryStream, transform, CryptoStreamMode.Read);
+            return converter(crypto);
+        }
 
-			crypto.GenerateKey();
-			crypto.GenerateIV();
+        /// <summary>
+        /// Generates an AES cryptography provider.
+        /// </summary>
+        /// <returns></returns>
+        private AesCryptoServiceProvider CreateCryptographyProvider()
+        {
+            return new AesCryptoServiceProvider
+            {
+                BlockSize = AesBlockSize,
+                Mode = _mode,
+                Padding = _padding,
+                Key = _key,
+                KeySize = _key.Length * 8
+            };
+        }
 
-			return new AesKeyInfo(crypto.Key, crypto.IV);
-		}
-	}
+        /// <summary>
+        /// Generates an AES key.
+        /// </summary>
+        /// <remarks>
+        /// The key size of the Aes encryption must be 128, 192 or 256 bits. 
+        /// Please check https://blogs.msdn.microsoft.com/shawnfa/2006/10/09/the-differences-between-rijndael-and-aes/ for more informations.
+        /// </remarks>
+        /// <param name="keySize">AES Key size</param>
+        /// <returns></returns>
+        public static AesKeyInfo GenerateKey(AesKeySize keySize)
+        {
+            var crypto = new AesCryptoServiceProvider
+            {
+                KeySize = (int)keySize,
+                BlockSize = AesBlockSize
+            };
+
+            crypto.GenerateKey();
+            crypto.GenerateIV();
+
+            return new AesKeyInfo(crypto.Key, crypto.IV);
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
@@ -6,36 +6,36 @@ using System.Security;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 {
-	public sealed class AuthorEntity
-	{
-		[Key]
-		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-		public int Id { get; set; }
+    public sealed class AuthorEntity
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
 
-		public Guid UniqueId { get; set; }
+        public Guid UniqueId { get; set; }
 
-		[Required]
-		[Encrypted]
-		public string FirstName { get; set; }
-		
-		[Required]
-		[Encrypted]
-		public string LastName { get; set; }
+        [Required]
+        [Encrypted]
+        public string FirstName { get; set; }
 
-		[Required]
-		public int Age { get; set; }
+        [Required]
+        [Encrypted]
+        public string LastName { get; set; }
 
-		public SecureString Password { get; set; }
+        [Required]
+        public int Age { get; set; }
 
-		public IList<BookEntity> Books { get; set; }
+        public SecureString Password { get; set; }
 
-		public AuthorEntity(string firstName, string lastName, int age)
-		{
-			FirstName = firstName;
-			LastName = lastName;
-			Age = age;
-			Books = new List<BookEntity>();
-			UniqueId = Guid.NewGuid();
-		}
-	}
+        public IList<BookEntity> Books { get; set; }
+
+        public AuthorEntity(string firstName, string lastName, int age)
+        {
+            FirstName = firstName;
+            LastName = lastName;
+            Age = age;
+            Books = new List<BookEntity>();
+            UniqueId = Guid.NewGuid();
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/AuthorEntity.cs
@@ -1,34 +1,41 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Security;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 {
-    public sealed class AuthorEntity
-    {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public int Id { get; set; }
+	public sealed class AuthorEntity
+	{
+		[Key]
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+		public int Id { get; set; }
 
-        [Required]
-        [Encrypted]
-        public string FirstName { get; set; }
-        
-        [Required]
-        [Encrypted]
-        public string LastName { get; set; }
+		public Guid UniqueId { get; set; }
 
-        [Required]
-        public int Age { get; set; }
+		[Required]
+		[Encrypted]
+		public string FirstName { get; set; }
+		
+		[Required]
+		[Encrypted]
+		public string LastName { get; set; }
 
-        public IList<BookEntity> Books { get; set; }
+		[Required]
+		public int Age { get; set; }
 
-        public AuthorEntity(string firstName, string lastName, int age)
-        {
-            FirstName = firstName;
-            LastName = lastName;
-            Age = age;
-            Books = new List<BookEntity>();
-        }
-    }
+		public SecureString Password { get; set; }
+
+		public IList<BookEntity> Books { get; set; }
+
+		public AuthorEntity(string firstName, string lastName, int age)
+		{
+			FirstName = firstName;
+			LastName = lastName;
+			Age = age;
+			Books = new List<BookEntity>();
+			UniqueId = Guid.NewGuid();
+		}
+	}
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
@@ -1,31 +1,35 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 {
-    public sealed class BookEntity
-    {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public int Id { get; set; }
+	public sealed class BookEntity
+	{
+		[Key]
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+		public int Id { get; set; }
 
-        [Required]
-        [Encrypted]
-        public string Name { get; set; }
+		public Guid UniqueId { get; set; }
 
-        [Required]
-        public int NumberOfPages { get; set; }
+		[Required]
+		[Encrypted]
+		public string Name { get; set; }
 
-        [Required]
-        public int AuthorId { get; set; }
+		[Required]
+		public int NumberOfPages { get; set; }
 
-        [ForeignKey(nameof(AuthorId))]
-        public AuthorEntity Author { get; set; }
+		[Required]
+		public int AuthorId { get; set; }
 
-        public BookEntity(string name, int numberOfPages)
-        {
-            Name = name;
-            NumberOfPages = numberOfPages;
-        }
-    }
+		[ForeignKey(nameof(AuthorId))]
+		public AuthorEntity Author { get; set; }
+
+		public BookEntity(string name, int numberOfPages)
+		{
+			Name = name;
+			NumberOfPages = numberOfPages;
+			UniqueId = Guid.NewGuid();
+		}
+	}
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/BookEntity.cs
@@ -4,32 +4,32 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 {
-	public sealed class BookEntity
-	{
-		[Key]
-		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-		public int Id { get; set; }
+    public sealed class BookEntity
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
 
-		public Guid UniqueId { get; set; }
+        public Guid UniqueId { get; set; }
 
-		[Required]
-		[Encrypted]
-		public string Name { get; set; }
+        [Required]
+        [Encrypted]
+        public string Name { get; set; }
 
-		[Required]
-		public int NumberOfPages { get; set; }
+        [Required]
+        public int NumberOfPages { get; set; }
 
-		[Required]
-		public int AuthorId { get; set; }
+        [Required]
+        public int AuthorId { get; set; }
 
-		[ForeignKey(nameof(AuthorId))]
-		public AuthorEntity Author { get; set; }
+        [ForeignKey(nameof(AuthorId))]
+        public AuthorEntity Author { get; set; }
 
-		public BookEntity(string name, int numberOfPages)
-		{
-			Name = name;
-			NumberOfPages = numberOfPages;
-			UniqueId = Guid.NewGuid();
-		}
-	}
+        public BookEntity(string name, int numberOfPages)
+        {
+            Name = name;
+            NumberOfPages = numberOfPages;
+            UniqueId = Guid.NewGuid();
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
@@ -4,53 +4,53 @@ using System.Data.Common;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 {
-	/// <summary>
-	/// Database context factory used to create entity framework new <see cref="DbContext"/>.
-	/// </summary>
-	public sealed class DatabaseContextFactory : IDisposable
-	{
-		private const string InMemoryDatabaseConnectionString = "DataSource=:memory:";
-		private const string DatabaseConnectionString = "DataSource={0}";
-		private readonly DbConnection _connection;
+    /// <summary>
+    /// Database context factory used to create entity framework new <see cref="DbContext"/>.
+    /// </summary>
+    public sealed class DatabaseContextFactory : IDisposable
+    {
+        private const string InMemoryDatabaseConnectionString = "DataSource=:memory:";
+        private const string DatabaseConnectionString = "DataSource={0}";
+        private readonly DbConnection _connection;
 
-		/// <summary>
-		/// Creates a new <see cref="DatabaseContextFactory"/> instance.
-		/// </summary>
-		public DatabaseContextFactory(string databaseName = null)
-		{
-			_connection = new SqliteConnection(string.IsNullOrEmpty(databaseName) ? InMemoryDatabaseConnectionString : DatabaseConnectionString.Replace("{0}", databaseName));
-			_connection.Open();
-		}
+        /// <summary>
+        /// Creates a new <see cref="DatabaseContextFactory"/> instance.
+        /// </summary>
+        public DatabaseContextFactory(string databaseName = null)
+        {
+            _connection = new SqliteConnection(string.IsNullOrEmpty(databaseName) ? InMemoryDatabaseConnectionString : DatabaseConnectionString.Replace("{0}", databaseName));
+            _connection.Open();
+        }
 
-		/// <summary>
-		/// Creates a new in memory database context.
-		/// </summary>
-		/// <typeparam name="TContext">Context</typeparam>
-		/// <param name="provider">Encryption provider</param>
-		/// <returns></returns>
-		public TContext CreateContext<TContext>(IEncryptionProvider provider = null) where TContext : DbContext
-		{
-			var context = Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
+        /// <summary>
+        /// Creates a new in memory database context.
+        /// </summary>
+        /// <typeparam name="TContext">Context</typeparam>
+        /// <param name="provider">Encryption provider</param>
+        /// <returns></returns>
+        public TContext CreateContext<TContext>(IEncryptionProvider provider = null) where TContext : DbContext
+        {
+            var context = Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
 
-			context.Database.EnsureCreated();
+            context.Database.EnsureCreated();
 
-			return context;
-		}
+            return context;
+        }
 
-		/// <summary>
-		/// Creates a new <see cref="DbContextOptions"/> instance using SQLite.
-		/// </summary>
-		/// <typeparam name="TContext"></typeparam>
-		/// <returns></returns>
-		public DbContextOptions<TContext> CreateOptions<TContext>() where TContext : DbContext 
-			=> new DbContextOptionsBuilder<TContext>().UseSqlite(_connection).Options;
+        /// <summary>
+        /// Creates a new <see cref="DbContextOptions"/> instance using SQLite.
+        /// </summary>
+        /// <typeparam name="TContext"></typeparam>
+        /// <returns></returns>
+        public DbContextOptions<TContext> CreateOptions<TContext>() where TContext : DbContext
+            => new DbContextOptionsBuilder<TContext>().UseSqlite(_connection).Options;
 
-		/// <summary>
-		/// Dispose the SQLite in memory connection.
-		/// </summary>
-		public void Dispose()
-		{
-			_connection?.Dispose();
-		}
-	}
+        /// <summary>
+        /// Dispose the SQLite in memory connection.
+        /// </summary>
+        public void Dispose()
+        {
+            _connection?.Dispose();
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Context/DatabaseContextFactory.cs
@@ -4,55 +4,53 @@ using System.Data.Common;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Context
 {
-    /// <summary>
-    /// Database context factory used to create entity framework new <see cref="DbContext"/>.
-    /// </summary>
-    public sealed class DatabaseContextFactory : IDisposable
-    {
-        private const string DatabaseConnectionString = "DataSource=:memory:";
-        private readonly DbConnection _connection;
+	/// <summary>
+	/// Database context factory used to create entity framework new <see cref="DbContext"/>.
+	/// </summary>
+	public sealed class DatabaseContextFactory : IDisposable
+	{
+		private const string InMemoryDatabaseConnectionString = "DataSource=:memory:";
+		private const string DatabaseConnectionString = "DataSource={0}";
+		private readonly DbConnection _connection;
 
-        /// <summary>
-        /// Creates a new <see cref="DatabaseContextFactory"/> instance.
-        /// </summary>
-        public DatabaseContextFactory()
-        {
-            _connection = new SqliteConnection(DatabaseConnectionString);
-            _connection.Open();
-        }
+		/// <summary>
+		/// Creates a new <see cref="DatabaseContextFactory"/> instance.
+		/// </summary>
+		public DatabaseContextFactory(string databaseName = null)
+		{
+			_connection = new SqliteConnection(string.IsNullOrEmpty(databaseName) ? InMemoryDatabaseConnectionString : DatabaseConnectionString.Replace("{0}", databaseName));
+			_connection.Open();
+		}
 
-        /// <summary>
-        /// Creates a new in memory database context.
-        /// </summary>
-        /// <typeparam name="TContext">Context</typeparam>
-        /// <param name="provider">Encryption provider</param>
-        /// <returns></returns>
-        public TContext CreateContext<TContext>(IEncryptionProvider provider = null) where TContext : DbContext
-        {
-            var context = Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
+		/// <summary>
+		/// Creates a new in memory database context.
+		/// </summary>
+		/// <typeparam name="TContext">Context</typeparam>
+		/// <param name="provider">Encryption provider</param>
+		/// <returns></returns>
+		public TContext CreateContext<TContext>(IEncryptionProvider provider = null) where TContext : DbContext
+		{
+			var context = Activator.CreateInstance(typeof(TContext), CreateOptions<TContext>(), provider) as TContext;
 
-            context.Database.EnsureCreated();
+			context.Database.EnsureCreated();
 
-            return context;
-        }
+			return context;
+		}
 
-        /// <summary>
-        /// Creates a new <see cref="DbContextOptions"/> instance using SQLite.
-        /// </summary>
-        /// <typeparam name="TContext"></typeparam>
-        /// <returns></returns>
-        private DbContextOptions<TContext> CreateOptions<TContext>() where TContext : DbContext 
-            => new DbContextOptionsBuilder<TContext>().UseSqlite(_connection).Options;
+		/// <summary>
+		/// Creates a new <see cref="DbContextOptions"/> instance using SQLite.
+		/// </summary>
+		/// <typeparam name="TContext"></typeparam>
+		/// <returns></returns>
+		public DbContextOptions<TContext> CreateOptions<TContext>() where TContext : DbContext 
+			=> new DbContextOptionsBuilder<TContext>().UseSqlite(_connection).Options;
 
-        /// <summary>
-        /// Dispose the SQLite in memory connection.
-        /// </summary>
-        public void Dispose()
-        {
-            if (_connection != null)
-            {
-                _connection.Dispose();
-            }
-        }
-    }
+		/// <summary>
+		/// Dispose the SQLite in memory connection.
+		/// </summary>
+		public void Dispose()
+		{
+			_connection?.Dispose();
+		}
+	}
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,30 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
-    <RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>
+	<TargetFramework>net5.0</TargetFramework>
+	<IsPackable>false</IsPackable>
+	<AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
+	<RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	<PackageReference Include="Bogus" Version="32.0.2" />
+	<PackageReference Include="coverlet.msbuild" Version="2.9.0">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+	<PackageReference Include="xunit" Version="2.4.1" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+	<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\EntityFrameworkCore.DataEncryption\EntityFrameworkCore.DataEncryption.csproj" />
+	<ProjectReference Include="..\..\src\EntityFrameworkCore.DataEncryption\EntityFrameworkCore.DataEncryption.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/EntityFrameworkCore.DataEncryption.Test/Helpers/DataHelper.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Helpers/DataHelper.cs
@@ -3,10 +3,17 @@ using System.Security;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Helpers
 {
-    public static class StringHelper
+    public static class DataHelper
     {
         private static readonly string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         private static readonly Random Randomizer = new();
+
+        public static byte[] RandomBytes(int length)
+        {
+            var result = new byte[length];
+            Randomizer.NextBytes(result);
+            return result;
+        }
 
         public static string RandomString(int length)
         {

--- a/test/EntityFrameworkCore.DataEncryption.Test/Helpers/StringHelper.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Helpers/StringHelper.cs
@@ -1,21 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Security;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Helpers
 {
-    public static class StringHelper
-    {
-        private static readonly string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        private static readonly Random Randomizer = new Random();
+	public static class StringHelper
+	{
+		private static readonly string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+		private static readonly Random Randomizer = new();
 
-        /// <summary>
-        /// Generates a new string.
-        /// </summary>
-        /// <param name="length"></param>
-        /// <returns></returns>
-        public static string RandomString(int length) 
-            => new string(Enumerable.Repeat(Characters, length).Select(s => s[Randomizer.Next(s.Length)]).ToArray());
-    }
+		public static string RandomString(int length)
+		{
+			var result = new char[length];
+			for (int i = 0; i < length; i++)
+			{
+				char c = Characters[Randomizer.Next(Characters.Length)];
+				result[i] = c;
+			}
+
+			return new(result);
+		}
+
+		public static SecureString RandomSecureString(int length)
+		{
+			var result = new SecureString();
+			for (int i = 0; i < length; i++)
+			{
+				char c = Characters[Randomizer.Next(Characters.Length)];
+				result.AppendChar(c);
+			}
+
+			return result;
+		}
+	}
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Helpers/StringHelper.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Helpers/StringHelper.cs
@@ -3,33 +3,33 @@ using System.Security;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Helpers
 {
-	public static class StringHelper
-	{
-		private static readonly string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-		private static readonly Random Randomizer = new();
+    public static class StringHelper
+    {
+        private static readonly string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        private static readonly Random Randomizer = new();
 
-		public static string RandomString(int length)
-		{
-			var result = new char[length];
-			for (int i = 0; i < length; i++)
-			{
-				char c = Characters[Randomizer.Next(Characters.Length)];
-				result[i] = c;
-			}
+        public static string RandomString(int length)
+        {
+            var result = new char[length];
+            for (int i = 0; i < length; i++)
+            {
+                char c = Characters[Randomizer.Next(Characters.Length)];
+                result[i] = c;
+            }
 
-			return new(result);
-		}
+            return new(result);
+        }
 
-		public static SecureString RandomSecureString(int length)
-		{
-			var result = new SecureString();
-			for (int i = 0; i < length; i++)
-			{
-				char c = Characters[Randomizer.Next(Characters.Length)];
-				result.AppendChar(c);
-			}
+        public static SecureString RandomSecureString(int length)
+        {
+            var result = new SecureString();
+            for (int i = 0; i < length; i++)
+            {
+                char c = Characters[Randomizer.Next(Characters.Length)];
+                result.AppendChar(c);
+            }
 
-			return result;
-		}
-	}
+            return result;
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+	public class EncryptedToOriginalMigratorTest : MigratorBaseTest
+	{
+		[Fact]
+		public async Task MigrateEncryptedToOriginalTest()
+		{
+			var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+			var sourceProvider = new AesProvider(aesKeys.Key);
+			var provider = new MigrationEncryptionProvider(sourceProvider, null);
+			await Execute(provider);
+		}
+	}
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/EncryptedToOriginalMigratorTest.cs
@@ -6,15 +6,15 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 {
-	public class EncryptedToOriginalMigratorTest : MigratorBaseTest
-	{
-		[Fact]
-		public async Task MigrateEncryptedToOriginalTest()
-		{
-			var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
-			var sourceProvider = new AesProvider(aesKeys.Key);
-			var provider = new MigrationEncryptionProvider(sourceProvider, null);
-			await Execute(provider);
-		}
-	}
+    public class EncryptedToOriginalMigratorTest : MigratorBaseTest
+    {
+        [Fact]
+        public async Task MigrateEncryptedToOriginalTest()
+        {
+            var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+            var sourceProvider = new AesProvider(aesKeys.Key);
+            var provider = new MigrationEncryptionProvider(sourceProvider, null);
+            await Execute(provider);
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Bogus;
-using Microsoft.EntityFrameworkCore.DataEncryption;
 using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
 using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
 using Xunit;
@@ -24,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
                 }).ToList();
         }
 
-        private void AssertAuthor(AuthorEntity expected, AuthorEntity actual)
+        private static void AssertAuthor(AuthorEntity expected, AuthorEntity actual)
         {
             Assert.NotNull(actual);
             Assert.Equal(expected.FirstName, actual.FirstName);

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
@@ -10,69 +10,69 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 {
-	public abstract class MigratorBaseTest
-	{
-		private IEnumerable<AuthorEntity> Authors { get; }
+    public abstract class MigratorBaseTest
+    {
+        private IEnumerable<AuthorEntity> Authors { get; }
 
-		protected MigratorBaseTest()
-		{
-			var faker = new Faker();
-			Authors = Enumerable.Range(0, faker.Random.Byte())
-				.Select(_ => new AuthorEntity(faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Int(0, 90))
-				{
-					Books = Enumerable.Range(0, 10).Select(_ => new BookEntity(faker.Lorem.Sentence(), faker.Random.Int(100, 500))).ToList()
-				}).ToList();
-		}
+        protected MigratorBaseTest()
+        {
+            var faker = new Faker();
+            Authors = Enumerable.Range(0, faker.Random.Byte())
+                .Select(_ => new AuthorEntity(faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Int(0, 90))
+                {
+                    Books = Enumerable.Range(0, 10).Select(_ => new BookEntity(faker.Lorem.Sentence(), faker.Random.Int(100, 500))).ToList()
+                }).ToList();
+        }
 
-		private void AssertAuthor(AuthorEntity expected, AuthorEntity actual)
-		{
-			Assert.NotNull(actual);
-			Assert.Equal(expected.FirstName, actual.FirstName);
-			Assert.Equal(expected.LastName, actual.LastName);
-			Assert.Equal(expected.Age, actual.Age);
-			Assert.Equal(expected.Books.Count, actual.Books.Count);
+        private void AssertAuthor(AuthorEntity expected, AuthorEntity actual)
+        {
+            Assert.NotNull(actual);
+            Assert.Equal(expected.FirstName, actual.FirstName);
+            Assert.Equal(expected.LastName, actual.LastName);
+            Assert.Equal(expected.Age, actual.Age);
+            Assert.Equal(expected.Books.Count, actual.Books.Count);
 
-			foreach (BookEntity actualBook in expected.Books)
-			{
-				BookEntity expectedBook = actual.Books.FirstOrDefault(x => x.UniqueId == actualBook.UniqueId);
+            foreach (BookEntity actualBook in expected.Books)
+            {
+                BookEntity expectedBook = actual.Books.FirstOrDefault(x => x.UniqueId == actualBook.UniqueId);
 
-				Assert.NotNull(expectedBook);
-				Assert.Equal(expectedBook.Name, actualBook.Name);
-				Assert.Equal(expectedBook.NumberOfPages, actualBook.NumberOfPages);
-			}
-		}
+                Assert.NotNull(expectedBook);
+                Assert.Equal(expectedBook.Name, actualBook.Name);
+                Assert.Equal(expectedBook.NumberOfPages, actualBook.NumberOfPages);
+            }
+        }
 
-		protected async Task Execute(MigrationEncryptionProvider provider)
-		{
-			string databaseName = Guid.NewGuid().ToString();
+        protected async Task Execute(MigrationEncryptionProvider provider)
+        {
+            string databaseName = Guid.NewGuid().ToString();
 
-			// Feed database with data.
-			using (var contextFactory = new DatabaseContextFactory(databaseName))
-			{
-				await using var context = contextFactory.CreateContext<DatabaseContext>(provider.SourceEncryptionProvider);
-				await context.Authors.AddRangeAsync(Authors);
-				await context.SaveChangesAsync();
-			}
+            // Feed database with data.
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                await using var context = contextFactory.CreateContext<DatabaseContext>(provider.SourceEncryptionProvider);
+                await context.Authors.AddRangeAsync(Authors);
+                await context.SaveChangesAsync();
+            }
 
-			// Process data migration
-			using (var contextFactory = new DatabaseContextFactory(databaseName))
-			{
-				await using var context = contextFactory.CreateContext<DatabaseContext>(provider);
-				await context.MigrateAsync();
-			}
+            // Process data migration
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                await using var context = contextFactory.CreateContext<DatabaseContext>(provider);
+                await context.MigrateAsync();
+            }
 
-			// Assert if the context has been decrypted
-			using (var contextFactory = new DatabaseContextFactory(databaseName))
-			{
-				await using var context = contextFactory.CreateContext<DatabaseContext>(provider.DestinationEncryptionProvider);
-				IEnumerable<AuthorEntity> authors = await context.Authors.Include(x => x.Books).ToListAsync();
+            // Assert if the context has been decrypted
+            using (var contextFactory = new DatabaseContextFactory(databaseName))
+            {
+                await using var context = contextFactory.CreateContext<DatabaseContext>(provider.DestinationEncryptionProvider);
+                IEnumerable<AuthorEntity> authors = await context.Authors.Include(x => x.Books).ToListAsync();
 
-				foreach (AuthorEntity author in authors)
-				{
-					AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
-					AssertAuthor(original, author);
-				}
-			}
-		}
-	}
+                foreach (AuthorEntity author in authors)
+                {
+                    AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+                    AssertAuthor(original, author);
+                }
+            }
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/MigratorBaseTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bogus;
+using Microsoft.EntityFrameworkCore.DataEncryption;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Test.Context;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+	public abstract class MigratorBaseTest
+	{
+		private IEnumerable<AuthorEntity> Authors { get; }
+
+		protected MigratorBaseTest()
+		{
+			var faker = new Faker();
+			Authors = Enumerable.Range(0, faker.Random.Byte())
+				.Select(_ => new AuthorEntity(faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Int(0, 90))
+				{
+					Books = Enumerable.Range(0, 10).Select(_ => new BookEntity(faker.Lorem.Sentence(), faker.Random.Int(100, 500))).ToList()
+				}).ToList();
+		}
+
+		private void AssertAuthor(AuthorEntity expected, AuthorEntity actual)
+		{
+			Assert.NotNull(actual);
+			Assert.Equal(expected.FirstName, actual.FirstName);
+			Assert.Equal(expected.LastName, actual.LastName);
+			Assert.Equal(expected.Age, actual.Age);
+			Assert.Equal(expected.Books.Count, actual.Books.Count);
+
+			foreach (BookEntity actualBook in expected.Books)
+			{
+				BookEntity expectedBook = actual.Books.FirstOrDefault(x => x.UniqueId == actualBook.UniqueId);
+
+				Assert.NotNull(expectedBook);
+				Assert.Equal(expectedBook.Name, actualBook.Name);
+				Assert.Equal(expectedBook.NumberOfPages, actualBook.NumberOfPages);
+			}
+		}
+
+		protected async Task Execute(MigrationEncryptionProvider provider)
+		{
+			string databaseName = Guid.NewGuid().ToString();
+
+			// Feed database with data.
+			using (var contextFactory = new DatabaseContextFactory(databaseName))
+			{
+				await using var context = contextFactory.CreateContext<DatabaseContext>(provider.SourceEncryptionProvider);
+				await context.Authors.AddRangeAsync(Authors);
+				await context.SaveChangesAsync();
+			}
+
+			// Process data migration
+			using (var contextFactory = new DatabaseContextFactory(databaseName))
+			{
+				await using var context = contextFactory.CreateContext<DatabaseContext>(provider);
+				await context.MigrateAsync();
+			}
+
+			// Assert if the context has been decrypted
+			using (var contextFactory = new DatabaseContextFactory(databaseName))
+			{
+				await using var context = contextFactory.CreateContext<DatabaseContext>(provider.DestinationEncryptionProvider);
+				IEnumerable<AuthorEntity> authors = await context.Authors.Include(x => x.Books).ToListAsync();
+
+				foreach (AuthorEntity author in authors)
+				{
+					AuthorEntity original = Authors.FirstOrDefault(x => x.UniqueId == author.UniqueId);
+					AssertAuthor(original, author);
+				}
+			}
+		}
+	}
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/OriginalToEncryptedMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/OriginalToEncryptedMigratorTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+	public class OriginalToEncryptedMigratorTest : MigratorBaseTest
+	{
+		[Fact]
+		public async Task MigrateOriginalToEncryptedTest()
+		{
+			var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+			var destinationProvider = new AesProvider(aesKeys.Key);
+			var provider = new MigrationEncryptionProvider(null, destinationProvider);
+			await Execute(provider);
+		}
+	}
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/OriginalToEncryptedMigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/OriginalToEncryptedMigratorTest.cs
@@ -6,15 +6,15 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 {
-	public class OriginalToEncryptedMigratorTest : MigratorBaseTest
-	{
-		[Fact]
-		public async Task MigrateOriginalToEncryptedTest()
-		{
-			var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
-			var destinationProvider = new AesProvider(aesKeys.Key);
-			var provider = new MigrationEncryptionProvider(null, destinationProvider);
-			await Execute(provider);
-		}
-	}
+    public class OriginalToEncryptedMigratorTest : MigratorBaseTest
+    {
+        [Fact]
+        public async Task MigrateOriginalToEncryptedTest()
+        {
+            var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+            var destinationProvider = new AesProvider(aesKeys.Key);
+            var provider = new MigrationEncryptionProvider(null, destinationProvider);
+            await Execute(provider);
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
@@ -11,7 +11,6 @@ namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
         [Fact]
         public async Task MigrateV1ToV2Test()
         {
-            string databaseName = $"{Guid.NewGuid()}.db";
             var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
             var sourceProvider = new AesProvider(aesKeys.Key, aesKeys.IV);
             var destinationProvider = new AesProvider(aesKeys.Key);

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.DataEncryption.Migration;
+using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
+{
+	public class V1ToV2MigratorTest : MigratorBaseTest
+	{
+		[Fact]
+		public async Task MigrateV1ToV2Test()
+		{
+			string databaseName = $"{Guid.NewGuid()}.db";
+			var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+			var sourceProvider = new AesProvider(aesKeys.Key, aesKeys.IV);
+			var destinationProvider = new AesProvider(aesKeys.Key);
+			var provider = new MigrationEncryptionProvider(sourceProvider, destinationProvider);
+			await Execute(provider);
+		}
+	}
+}

--- a/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Migration/V1ToV2MigratorTest.cs
@@ -6,17 +6,17 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Encryption.Test.Migration
 {
-	public class V1ToV2MigratorTest : MigratorBaseTest
-	{
-		[Fact]
-		public async Task MigrateV1ToV2Test()
-		{
-			string databaseName = $"{Guid.NewGuid()}.db";
-			var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
-			var sourceProvider = new AesProvider(aesKeys.Key, aesKeys.IV);
-			var destinationProvider = new AesProvider(aesKeys.Key);
-			var provider = new MigrationEncryptionProvider(sourceProvider, destinationProvider);
-			await Execute(provider);
-		}
-	}
+    public class V1ToV2MigratorTest : MigratorBaseTest
+    {
+        [Fact]
+        public async Task MigrateV1ToV2Test()
+        {
+            string databaseName = $"{Guid.NewGuid()}.db";
+            var aesKeys = AesProvider.GenerateKey(AesKeySize.AES256Bits);
+            var sourceProvider = new AesProvider(aesKeys.Key, aesKeys.IV);
+            var destinationProvider = new AesProvider(aesKeys.Key);
+            var provider = new MigrationEncryptionProvider(sourceProvider, destinationProvider);
+            await Execute(provider);
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
@@ -11,148 +11,148 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
 {
-	public class AesProviderTest
-	{
-		[Theory]
-		[InlineData(AesKeySize.AES128Bits)]
-		[InlineData(AesKeySize.AES192Bits)]
-		[InlineData(AesKeySize.AES256Bits)]
-		public void EncryptDecryptStringTest(AesKeySize keySize)
-		{
-			string input = StringHelper.RandomString(20);
-			AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
-			var provider = new AesProvider(encryptionKeyInfo.Key);
+    public class AesProviderTest
+    {
+        [Theory]
+        [InlineData(AesKeySize.AES128Bits)]
+        [InlineData(AesKeySize.AES192Bits)]
+        [InlineData(AesKeySize.AES256Bits)]
+        public void EncryptDecryptStringTest(AesKeySize keySize)
+        {
+            string input = StringHelper.RandomString(20);
+            AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
+            var provider = new AesProvider(encryptionKeyInfo.Key);
 
-			string encryptedData = provider.Encrypt(input, Encoding.UTF8.GetBytes, ConverterBuilder.StreamToBase64String);
-			Assert.NotNull(encryptedData);
+            string encryptedData = provider.Encrypt(input, Encoding.UTF8.GetBytes, ConverterBuilder.StreamToBase64String);
+            Assert.NotNull(encryptedData);
 
-			string decryptedData = provider.Decrypt(encryptedData, Convert.FromBase64String, ConverterBuilder.StreamToString);
-			Assert.NotNull(decryptedData);
+            string decryptedData = provider.Decrypt(encryptedData, Convert.FromBase64String, ConverterBuilder.StreamToString);
+            Assert.NotNull(decryptedData);
 
-			Assert.Equal(input, decryptedData);
-		}
+            Assert.Equal(input, decryptedData);
+        }
 
-		[Theory]
-		[InlineData(AesKeySize.AES128Bits)]
-		[InlineData(AesKeySize.AES192Bits)]
-		[InlineData(AesKeySize.AES256Bits)]
-		public void GenerateAesKeyTest(AesKeySize keySize)
-		{
-			AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
+        [Theory]
+        [InlineData(AesKeySize.AES128Bits)]
+        [InlineData(AesKeySize.AES192Bits)]
+        [InlineData(AesKeySize.AES256Bits)]
+        public void GenerateAesKeyTest(AesKeySize keySize)
+        {
+            AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
 
-			Assert.NotNull(encryptionKeyInfo.Key);
-			Assert.NotNull(encryptionKeyInfo.IV);
-			Assert.Equal((int)keySize / 8, encryptionKeyInfo.Key.Length);
-		}
+            Assert.NotNull(encryptionKeyInfo.Key);
+            Assert.NotNull(encryptionKeyInfo.IV);
+            Assert.Equal((int)keySize / 8, encryptionKeyInfo.Key.Length);
+        }
 
-		[Theory]
-		[InlineData(AesKeySize.AES128Bits)]
-		[InlineData(AesKeySize.AES192Bits)]
-		[InlineData(AesKeySize.AES256Bits)]
-		public void CompareTwoAesKeysInstancesTest(AesKeySize keySize)
-		{
-			AesKeyInfo encryptionKeyInfo1 = AesProvider.GenerateKey(keySize);
-			AesKeyInfo encryptionKeyInfo2 = AesProvider.GenerateKey(keySize);
-			AesKeyInfo encryptionKeyInfoCopy = encryptionKeyInfo1;
+        [Theory]
+        [InlineData(AesKeySize.AES128Bits)]
+        [InlineData(AesKeySize.AES192Bits)]
+        [InlineData(AesKeySize.AES256Bits)]
+        public void CompareTwoAesKeysInstancesTest(AesKeySize keySize)
+        {
+            AesKeyInfo encryptionKeyInfo1 = AesProvider.GenerateKey(keySize);
+            AesKeyInfo encryptionKeyInfo2 = AesProvider.GenerateKey(keySize);
+            AesKeyInfo encryptionKeyInfoCopy = encryptionKeyInfo1;
 
-			Assert.NotNull(encryptionKeyInfo1.Key);
-			Assert.NotNull(encryptionKeyInfo1.IV);
-			Assert.NotNull(encryptionKeyInfo2.Key);
-			Assert.NotNull(encryptionKeyInfo2.IV);
-			Assert.True(encryptionKeyInfo1 == encryptionKeyInfoCopy);
-			Assert.True(encryptionKeyInfo1.Equals(encryptionKeyInfoCopy));
-			Assert.True(encryptionKeyInfo1 != encryptionKeyInfo2);
-			Assert.True(encryptionKeyInfo1.GetHashCode() != encryptionKeyInfo2.GetHashCode());
-			Assert.False(encryptionKeyInfo1.Equals(0));
-		}
+            Assert.NotNull(encryptionKeyInfo1.Key);
+            Assert.NotNull(encryptionKeyInfo1.IV);
+            Assert.NotNull(encryptionKeyInfo2.Key);
+            Assert.NotNull(encryptionKeyInfo2.IV);
+            Assert.True(encryptionKeyInfo1 == encryptionKeyInfoCopy);
+            Assert.True(encryptionKeyInfo1.Equals(encryptionKeyInfoCopy));
+            Assert.True(encryptionKeyInfo1 != encryptionKeyInfo2);
+            Assert.True(encryptionKeyInfo1.GetHashCode() != encryptionKeyInfo2.GetHashCode());
+            Assert.False(encryptionKeyInfo1.Equals(0));
+        }
 
-		[Fact]
-		public void CreateDataContextWithoutProvider()
-		{
-			using var contextFactory = new DatabaseContextFactory();
-			using var context = contextFactory.CreateContext<SimpleEncryptedDatabaseContext>();
-			Assert.NotNull(context);
-		}
+        [Fact]
+        public void CreateDataContextWithoutProvider()
+        {
+            using var contextFactory = new DatabaseContextFactory();
+            using var context = contextFactory.CreateContext<SimpleEncryptedDatabaseContext>();
+            Assert.NotNull(context);
+        }
 
-		[Fact]
-		public void EncryptUsingAes128Provider()
-		{
-			ExecuteAesEncryptionTest<Aes128EncryptedDatabaseContext>(AesKeySize.AES128Bits);
-		}
+        [Fact]
+        public void EncryptUsingAes128Provider()
+        {
+            ExecuteAesEncryptionTest<Aes128EncryptedDatabaseContext>(AesKeySize.AES128Bits);
+        }
 
-		[Fact]
-		public void EncryptUsingAes192Provider()
-		{
-			ExecuteAesEncryptionTest<Aes192EncryptedDatabaseContext>(AesKeySize.AES192Bits);
-		}
+        [Fact]
+        public void EncryptUsingAes192Provider()
+        {
+            ExecuteAesEncryptionTest<Aes192EncryptedDatabaseContext>(AesKeySize.AES192Bits);
+        }
 
-		[Fact]
-		public void EncryptUsingAes256Provider()
-		{
-			ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
-		}
+        [Fact]
+        public void EncryptUsingAes256Provider()
+        {
+            ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
+        }
 
-		private void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
-		{
-			AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(aesKeyType);
-			var provider = new AesProvider(encryptionKeyInfo.Key, CipherMode.CBC, PaddingMode.Zeros);
-			var author = new AuthorEntity("John", "Doe", 42)
-			{
-				Password = StringHelper.RandomSecureString(10),
-				Books = new List<BookEntity>
-				{
-					new("Lorem Ipsum", 300),
-					new("Dolor sit amet", 390)
-				}
-			};
+        private void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
+        {
+            AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(aesKeyType);
+            var provider = new AesProvider(encryptionKeyInfo.Key, CipherMode.CBC, PaddingMode.Zeros);
+            var author = new AuthorEntity("John", "Doe", 42)
+            {
+                Password = StringHelper.RandomSecureString(10),
+                Books = new List<BookEntity>
+                {
+                    new("Lorem Ipsum", 300),
+                    new("Dolor sit amet", 390)
+                }
+            };
 
-			using var contextFactory = new DatabaseContextFactory();
+            using var contextFactory = new DatabaseContextFactory();
 
-			// Save data to an encrypted database context
-			using (var dbContext = contextFactory.CreateContext<TContext>(provider))
-			{
-				dbContext.Authors.Add(author);
-				dbContext.SaveChanges();
-			}
+            // Save data to an encrypted database context
+            using (var dbContext = contextFactory.CreateContext<TContext>(provider))
+            {
+                dbContext.Authors.Add(author);
+                dbContext.SaveChanges();
+            }
 
-			// Read decrypted data and compare with original data
-			using (var dbContext = contextFactory.CreateContext<TContext>(provider))
-			{
-				var authorFromDb = dbContext.Authors.Include(x => x.Books).FirstOrDefault();
+            // Read decrypted data and compare with original data
+            using (var dbContext = contextFactory.CreateContext<TContext>(provider))
+            {
+                var authorFromDb = dbContext.Authors.Include(x => x.Books).FirstOrDefault();
 
-				Assert.NotNull(authorFromDb);
-				Assert.Equal(author.FirstName, authorFromDb.FirstName);
-				Assert.Equal(author.LastName, authorFromDb.LastName);
-				Assert.NotNull(authorFromDb.Books);
-				Assert.NotEmpty(authorFromDb.Books);
-				Assert.Equal(2, authorFromDb.Books.Count);
-				Assert.Equal(author.Books.First().Name, authorFromDb.Books.First().Name);
-				Assert.Equal(author.Books.Last().Name, authorFromDb.Books.Last().Name);
-			}
-		}
+                Assert.NotNull(authorFromDb);
+                Assert.Equal(author.FirstName, authorFromDb.FirstName);
+                Assert.Equal(author.LastName, authorFromDb.LastName);
+                Assert.NotNull(authorFromDb.Books);
+                Assert.NotEmpty(authorFromDb.Books);
+                Assert.Equal(2, authorFromDb.Books.Count);
+                Assert.Equal(author.Books.First().Name, authorFromDb.Books.First().Name);
+                Assert.Equal(author.Books.Last().Name, authorFromDb.Books.Last().Name);
+            }
+        }
 
-		public class Aes128EncryptedDatabaseContext : DatabaseContext
-		{
-			public Aes128EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-				: base(options, encryptionProvider) { }
-		}
+        public class Aes128EncryptedDatabaseContext : DatabaseContext
+        {
+            public Aes128EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider) { }
+        }
 
-		public class Aes192EncryptedDatabaseContext : DatabaseContext
-		{
-			public Aes192EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-				: base(options, encryptionProvider) { }
-		}
+        public class Aes192EncryptedDatabaseContext : DatabaseContext
+        {
+            public Aes192EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider) { }
+        }
 
-		public class Aes256EncryptedDatabaseContext : DatabaseContext
-		{
-			public Aes256EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-				: base(options, encryptionProvider) { }
-		}
+        public class Aes256EncryptedDatabaseContext : DatabaseContext
+        {
+            public Aes256EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider) { }
+        }
 
-		public class SimpleEncryptedDatabaseContext : DatabaseContext
-		{
-			public SimpleEncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-				: base(options, encryptionProvider) { }
-		}
-	}
+        public class SimpleEncryptedDatabaseContext : DatabaseContext
+        {
+            public SimpleEncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+                : base(options, encryptionProvider) { }
+        }
+    }
 }

--- a/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
@@ -23,10 +23,10 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
             AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
             var provider = new AesProvider(encryptionKeyInfo.Key);
 
-            string encryptedData = provider.Encrypt(input, Encoding.UTF8.GetBytes, ConverterBuilder.StreamToBase64String);
+            string encryptedData = provider.Encrypt(input, Encoding.UTF8.GetBytes, StandardConverters.StreamToBase64String);
             Assert.NotNull(encryptedData);
 
-            string decryptedData = provider.Decrypt(encryptedData, Convert.FromBase64String, ConverterBuilder.StreamToString);
+            string decryptedData = provider.Decrypt(encryptedData, Convert.FromBase64String, StandardConverters.StreamToString);
             Assert.NotNull(decryptedData);
 
             Assert.Equal(input, decryptedData);

--- a/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
             ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
         }
 
-        private void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
+        private static void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
         {
             AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(aesKeyType);
             var provider = new AesProvider(encryptionKeyInfo.Key, CipherMode.CBC, PaddingMode.Zeros);

--- a/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
+++ b/test/EntityFrameworkCore.DataEncryption.Test/Providers/AesProviderTest.cs
@@ -5,153 +5,154 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore.DataEncryption.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.DataEncryption.Test.Providers
 {
-    public class AesProviderTest
-    {
-        [Theory]
-        [InlineData(AesKeySize.AES128Bits)]
-        [InlineData(AesKeySize.AES192Bits)]
-        [InlineData(AesKeySize.AES256Bits)]
-        public void EncryptDecryptStringTest(AesKeySize keySize)
-        {
-            string input = StringHelper.RandomString(20);
-            AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
-            var provider = new AesProvider(encryptionKeyInfo.Key);
+	public class AesProviderTest
+	{
+		[Theory]
+		[InlineData(AesKeySize.AES128Bits)]
+		[InlineData(AesKeySize.AES192Bits)]
+		[InlineData(AesKeySize.AES256Bits)]
+		public void EncryptDecryptStringTest(AesKeySize keySize)
+		{
+			string input = StringHelper.RandomString(20);
+			AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
+			var provider = new AesProvider(encryptionKeyInfo.Key);
 
-            string encryptedData = provider.Encrypt(input);
-            Assert.NotNull(encryptedData);
+			string encryptedData = provider.Encrypt(input, Encoding.UTF8.GetBytes, ConverterBuilder.StreamToBase64String);
+			Assert.NotNull(encryptedData);
 
-            string decryptedData = provider.Decrypt(encryptedData);
-            Assert.NotNull(decryptedData);
+			string decryptedData = provider.Decrypt(encryptedData, Convert.FromBase64String, ConverterBuilder.StreamToString);
+			Assert.NotNull(decryptedData);
 
-            Assert.Equal(input, decryptedData);
-        }
+			Assert.Equal(input, decryptedData);
+		}
 
-        [Theory]
-        [InlineData(AesKeySize.AES128Bits)]
-        [InlineData(AesKeySize.AES192Bits)]
-        [InlineData(AesKeySize.AES256Bits)]
-        public void GenerateAesKeyTest(AesKeySize keySize)
-        {
-            AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
+		[Theory]
+		[InlineData(AesKeySize.AES128Bits)]
+		[InlineData(AesKeySize.AES192Bits)]
+		[InlineData(AesKeySize.AES256Bits)]
+		public void GenerateAesKeyTest(AesKeySize keySize)
+		{
+			AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(keySize);
 
-            Assert.NotNull(encryptionKeyInfo.Key);
-            Assert.NotNull(encryptionKeyInfo.IV);
-            Assert.Equal((int)keySize / 8, encryptionKeyInfo.Key.Length);
-        }
+			Assert.NotNull(encryptionKeyInfo.Key);
+			Assert.NotNull(encryptionKeyInfo.IV);
+			Assert.Equal((int)keySize / 8, encryptionKeyInfo.Key.Length);
+		}
 
-        [Theory]
-        [InlineData(AesKeySize.AES128Bits)]
-        [InlineData(AesKeySize.AES192Bits)]
-        [InlineData(AesKeySize.AES256Bits)]
-        public void CompareTwoAesKeysInstancesTest(AesKeySize keySize)
-        {
-            AesKeyInfo encryptionKeyInfo1 = AesProvider.GenerateKey(keySize);
-            AesKeyInfo encryptionKeyInfo2 = AesProvider.GenerateKey(keySize);
-            AesKeyInfo encryptionKeyInfoCopy = encryptionKeyInfo1;
+		[Theory]
+		[InlineData(AesKeySize.AES128Bits)]
+		[InlineData(AesKeySize.AES192Bits)]
+		[InlineData(AesKeySize.AES256Bits)]
+		public void CompareTwoAesKeysInstancesTest(AesKeySize keySize)
+		{
+			AesKeyInfo encryptionKeyInfo1 = AesProvider.GenerateKey(keySize);
+			AesKeyInfo encryptionKeyInfo2 = AesProvider.GenerateKey(keySize);
+			AesKeyInfo encryptionKeyInfoCopy = encryptionKeyInfo1;
 
-            Assert.NotNull(encryptionKeyInfo1.Key);
-            Assert.NotNull(encryptionKeyInfo1.IV);
-            Assert.NotNull(encryptionKeyInfo2.Key);
-            Assert.NotNull(encryptionKeyInfo2.IV);
-            Assert.True(encryptionKeyInfo1 == encryptionKeyInfoCopy);
-            Assert.True(encryptionKeyInfo1.Equals(encryptionKeyInfoCopy));
-            Assert.True(encryptionKeyInfo1 != encryptionKeyInfo2);
-            Assert.True(encryptionKeyInfo1.GetHashCode() != encryptionKeyInfo2.GetHashCode());
-            Assert.False(encryptionKeyInfo1.Equals(0));
-        }
+			Assert.NotNull(encryptionKeyInfo1.Key);
+			Assert.NotNull(encryptionKeyInfo1.IV);
+			Assert.NotNull(encryptionKeyInfo2.Key);
+			Assert.NotNull(encryptionKeyInfo2.IV);
+			Assert.True(encryptionKeyInfo1 == encryptionKeyInfoCopy);
+			Assert.True(encryptionKeyInfo1.Equals(encryptionKeyInfoCopy));
+			Assert.True(encryptionKeyInfo1 != encryptionKeyInfo2);
+			Assert.True(encryptionKeyInfo1.GetHashCode() != encryptionKeyInfo2.GetHashCode());
+			Assert.False(encryptionKeyInfo1.Equals(0));
+		}
 
-        [Fact]
-        public void CreateDataContextWithoutProvider()
-        {
-            using (var contextFactory = new DatabaseContextFactory())
-            {
-                Assert.Throws<ArgumentNullException>(() => contextFactory.CreateContext<SimpleEncryptedDatabaseContext>());
-            }
-        }
+		[Fact]
+		public void CreateDataContextWithoutProvider()
+		{
+			using var contextFactory = new DatabaseContextFactory();
+			using var context = contextFactory.CreateContext<SimpleEncryptedDatabaseContext>();
+			Assert.NotNull(context);
+		}
 
-        [Fact]
-        public void EncryptUsingAes128Provider()
-        {
-            ExecuteAesEncryptionTest<Aes128EncryptedDatabaseContext>(AesKeySize.AES128Bits);
-        }
+		[Fact]
+		public void EncryptUsingAes128Provider()
+		{
+			ExecuteAesEncryptionTest<Aes128EncryptedDatabaseContext>(AesKeySize.AES128Bits);
+		}
 
-        [Fact]
-        public void EncryptUsingAes192Provider()
-        {
-            ExecuteAesEncryptionTest<Aes192EncryptedDatabaseContext>(AesKeySize.AES192Bits);
-        }
+		[Fact]
+		public void EncryptUsingAes192Provider()
+		{
+			ExecuteAesEncryptionTest<Aes192EncryptedDatabaseContext>(AesKeySize.AES192Bits);
+		}
 
-        [Fact]
-        public void EncryptUsingAes256Provider()
-        {
-            ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
-        }
+		[Fact]
+		public void EncryptUsingAes256Provider()
+		{
+			ExecuteAesEncryptionTest<Aes256EncryptedDatabaseContext>(AesKeySize.AES256Bits);
+		}
 
-        private void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
-        {
-            AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(aesKeyType);
-            var provider = new AesProvider(encryptionKeyInfo.Key, CipherMode.CBC, PaddingMode.Zeros);
-            var author = new AuthorEntity("John", "Doe", 42)
-            {
-                Books = new List<BookEntity>()
-                {
-                    new BookEntity("Lorem Ipsum", 300),
-                    new BookEntity("Dolor sit amet", 390)
-                }
-            };
+		private void ExecuteAesEncryptionTest<TContext>(AesKeySize aesKeyType) where TContext : DatabaseContext
+		{
+			AesKeyInfo encryptionKeyInfo = AesProvider.GenerateKey(aesKeyType);
+			var provider = new AesProvider(encryptionKeyInfo.Key, CipherMode.CBC, PaddingMode.Zeros);
+			var author = new AuthorEntity("John", "Doe", 42)
+			{
+				Password = StringHelper.RandomSecureString(10),
+				Books = new List<BookEntity>
+				{
+					new("Lorem Ipsum", 300),
+					new("Dolor sit amet", 390)
+				}
+			};
 
-            using (var contextFactory = new DatabaseContextFactory())
-            {
-                // Save data to an encrypted database context
-                using (var dbContext = contextFactory.CreateContext<TContext>(provider))
-                {
-                    dbContext.Authors.Add(author);
-                    dbContext.SaveChanges();
-                }
+			using var contextFactory = new DatabaseContextFactory();
 
-                // Read decrypted data and compare with original data
-                using (var dbContext = contextFactory.CreateContext<TContext>(provider))
-                {
-                    var authorFromDb = dbContext.Authors.Include(x => x.Books).FirstOrDefault();
+			// Save data to an encrypted database context
+			using (var dbContext = contextFactory.CreateContext<TContext>(provider))
+			{
+				dbContext.Authors.Add(author);
+				dbContext.SaveChanges();
+			}
 
-                    Assert.NotNull(authorFromDb);
-                    Assert.Equal(author.FirstName, authorFromDb.FirstName);
-                    Assert.Equal(author.LastName, authorFromDb.LastName);
-                    Assert.NotNull(authorFromDb.Books);
-                    Assert.NotEmpty(authorFromDb.Books);
-                    Assert.Equal(2, authorFromDb.Books.Count);
-                    Assert.Equal(author.Books.First().Name, authorFromDb.Books.First().Name);
-                    Assert.Equal(author.Books.Last().Name, authorFromDb.Books.Last().Name);
-                }
-            }
-        }
+			// Read decrypted data and compare with original data
+			using (var dbContext = contextFactory.CreateContext<TContext>(provider))
+			{
+				var authorFromDb = dbContext.Authors.Include(x => x.Books).FirstOrDefault();
 
-        public class Aes128EncryptedDatabaseContext : DatabaseContext
-        {
-            public Aes128EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-                : base(options, encryptionProvider) { }
-        }
+				Assert.NotNull(authorFromDb);
+				Assert.Equal(author.FirstName, authorFromDb.FirstName);
+				Assert.Equal(author.LastName, authorFromDb.LastName);
+				Assert.NotNull(authorFromDb.Books);
+				Assert.NotEmpty(authorFromDb.Books);
+				Assert.Equal(2, authorFromDb.Books.Count);
+				Assert.Equal(author.Books.First().Name, authorFromDb.Books.First().Name);
+				Assert.Equal(author.Books.Last().Name, authorFromDb.Books.Last().Name);
+			}
+		}
 
-        public class Aes192EncryptedDatabaseContext : DatabaseContext
-        {
-            public Aes192EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-                : base(options, encryptionProvider) { }
-        }
+		public class Aes128EncryptedDatabaseContext : DatabaseContext
+		{
+			public Aes128EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+				: base(options, encryptionProvider) { }
+		}
 
-        public class Aes256EncryptedDatabaseContext : DatabaseContext
-        {
-            public Aes256EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-                : base(options, encryptionProvider) { }
-        }
+		public class Aes192EncryptedDatabaseContext : DatabaseContext
+		{
+			public Aes192EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+				: base(options, encryptionProvider) { }
+		}
 
-        public class SimpleEncryptedDatabaseContext : DatabaseContext
-        {
-            public SimpleEncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
-                : base(options, encryptionProvider) { }
-        }
-    }
+		public class Aes256EncryptedDatabaseContext : DatabaseContext
+		{
+			public Aes256EncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+				: base(options, encryptionProvider) { }
+		}
+
+		public class SimpleEncryptedDatabaseContext : DatabaseContext
+		{
+			public SimpleEncryptedDatabaseContext(DbContextOptions options, IEncryptionProvider encryptionProvider = null)
+				: base(options, encryptionProvider) { }
+		}
+	}
 }


### PR DESCRIPTION
This update adds support for model properties of type `SecureString` and `byte[]` in addition to `string`.

It also supports storing the encrypted values in `varbinary` columns instead of Base64-encoded `varchar` columns.

I've also added basic migration support for moving between encryption providers (including to and from unencrypted data).

And finally, I've restored the "fixed IV" option on the `AesProvider` for cases where the encrypted column needs to be searched with LINQ, or where the IV being changed on every update causes problems.