### PR TITLE
Update the library to support .Net6 and EF Core 6.

### DIFF
--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -5,7 +5,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '5.0.x'
+    version: '6.0.x'
 
 # Build solution
 - script: |

--- a/samples/AesSample/AesSample.csproj
+++ b/samples/AesSample/AesSample.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
 		<RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
     <IsPackable>true</IsPackable>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<Authors>Filipe GOMES PEIXOTO</Authors>
 		<PackageId>EntityFrameworkCore.DataEncryption</PackageId>
 		<PackageProjectUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption</PackageProjectUrl>
@@ -29,7 +29,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
             var set = context.Set(property.DeclaringEntityType);
             var list = await set.ToListAsync(cancellationToken);
 
-            logger?.LogInformation("Migrating data for {EntityType} :: {Property}} ({RecordCount} records)...",
+            logger?.LogInformation("Migrating data for {EntityType} :: {Property} ({RecordCount} records)...",
                 property.DeclaringEntityType.Name, property.Name, list.Count);
 
             foreach (var entity in list)

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
+	<TargetFramework>net6.0</TargetFramework>
 	<IsPackable>false</IsPackable>
 	<AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
 	<RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Bogus" Version="32.0.2" />
-	<PackageReference Include="coverlet.msbuild" Version="2.9.0">
+	<PackageReference Include="Bogus" Version="33.1.1" />
+	<PackageReference Include="coverlet.msbuild" Version="3.1.0">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-	<PackageReference Include="xunit" Version="2.4.1" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
When updating a project to .Net6 that uses this amazing encryption library it would not run the DB migrations because of a missing method exception for ClrType. I believe this was due to this library targeting the wrong version of EF Core. This PR upgrades the library to EF Core 6.0 and resolves the issue with running migrations on EF Core 6 projects.

It would be great if the nuget package could also get updated.