### PR TITLE
Adding support for EF Core 6 and .Net 6.0

### DIFF
--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -9,12 +9,12 @@ steps:
 
 # Build solution
 - script: |
-    dotnet build EntityFrameworkCore.DataEncryption.sln --configuration Release -f net5
+    dotnet build EntityFrameworkCore.DataEncryption.sln --configuration Release -f net6.0
   displayName: 'Build'
 
 # Test solution
 - script: |
-    dotnet test EntityFrameworkCore.DataEncryption.sln --configuration Release /p:CollectCoverage=true /p:Exclude="[xunit*]*" /p:CoverletOutputFormat=opencover /p:CoverletOutput="../TestResults/TestResults.xml" /maxcpucount:1 -f net5
+    dotnet test EntityFrameworkCore.DataEncryption.sln --configuration Release /p:CollectCoverage=true /p:Exclude="[xunit*]*" /p:CoverletOutputFormat=opencover /p:CoverletOutput="../TestResults/TestResults.xml" /maxcpucount:1 -f net6.0
   displayName: 'Test'
 
 # Upload coverage

--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -5,7 +5,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '5.0.x'
+    version: '6.0.x'
 
 # Build solution
 - script: |

--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -9,12 +9,12 @@ steps:
 
 # Build solution
 - script: |
-    dotnet build EntityFrameworkCore.DataEncryption.sln --configuration Release
+    dotnet build EntityFrameworkCore.DataEncryption.sln --configuration Release -f net5
   displayName: 'Build'
 
 # Test solution
 - script: |
-    dotnet test EntityFrameworkCore.DataEncryption.sln --configuration Release /p:CollectCoverage=true /p:Exclude="[xunit*]*" /p:CoverletOutputFormat=opencover /p:CoverletOutput="../TestResults/TestResults.xml" /maxcpucount:1
+    dotnet test EntityFrameworkCore.DataEncryption.sln --configuration Release /p:CollectCoverage=true /p:Exclude="[xunit*]*" /p:CoverletOutputFormat=opencover /p:CoverletOutput="../TestResults/TestResults.xml" /maxcpucount:1 -f net5
   displayName: 'Test'
 
 # Upload coverage

--- a/samples/AesSample/AesSample.csproj
+++ b/samples/AesSample/AesSample.csproj
@@ -2,13 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
-  </ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net5.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5,)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[5,)" />
+	</ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net6.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6,)" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFrameworkCore.DataEncryption\EntityFrameworkCore.DataEncryption.csproj" />

--- a/samples/AesSample/AesSample.csproj
+++ b/samples/AesSample/AesSample.csproj
@@ -8,10 +8,12 @@
 	<ItemGroup Condition="('$(TargetFramework)' == 'net5.0')">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5,)" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[5,)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[5,)" />
 	</ItemGroup>
 	<ItemGroup Condition="('$(TargetFramework)' == 'net6.0')">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,)" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6,)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6,)" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net5.0</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
@@ -28,10 +28,22 @@
 	  <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+	<ItemGroup Condition="('$(TargetFramework)' == 'netstandard2.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,6)" />
 	</ItemGroup>
-
+	<ItemGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,6)" />
+	</ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'netstandard2.1')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5,)" />
+	</ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net5.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5,)" />
+	</ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net6.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,)" />
+	</ItemGroup>
+	
 	<ItemGroup>
 		<None Include="..\..\LICENSE">
 			<Pack>True</Pack>

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -7,7 +7,7 @@
 		<AssemblyName>EntityFrameworkCore.DataEncryption</AssemblyName>
 		<RootNamespace>Microsoft.EntityFrameworkCore.DataEncryption</RootNamespace>
     <IsPackable>true</IsPackable>
-		<Version>3.0.0</Version>
+		<Version>3.0.1-dev</Version>
 		<Authors>Filipe GOMES PEIXOTO</Authors>
 		<PackageId>EntityFrameworkCore.DataEncryption</PackageId>
 		<PackageProjectUrl>https://github.com/Eastrall/EntityFrameworkCore.DataEncryption</PackageProjectUrl>

--- a/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Migration/EncryptionMigrator.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.DataEncryption.Migration
             var set = context.Set(property.DeclaringEntityType);
             var list = await set.ToListAsync(cancellationToken);
 
-            logger?.LogInformation("Migrating data for {EntityType} :: {Property}} ({RecordCount} records)...",
+            logger?.LogInformation("Migrating data for {EntityType} :: {Property} ({RecordCount} records)...",
                 property.DeclaringEntityType.Name, property.Name, list.Count);
 
             foreach (var entity in list)

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net5.0</TargetFramework>
 	<IsPackable>false</IsPackable>
 	<AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
 	<RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -13,8 +13,7 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-	
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
+
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
 	<PackageReference Include="xunit" Version="2.4.1" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
+	<TargetFramework>net6.0</TargetFramework>
 	<IsPackable>false</IsPackable>
 	<AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
 	<RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>

--- a/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
+++ b/test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
+	<TargetFramework>net6.0</TargetFramework>
 	<IsPackable>false</IsPackable>
 	<AssemblyName>Microsoft.EntityFrameworkCore.Encryption.Test</AssemblyName>
 	<RootNamespace>Microsoft.EntityFrameworkCore.Encryption.Test</RootNamespace>
@@ -13,7 +13,7 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
+	
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
 	<PackageReference Include="xunit" Version="2.4.1" />
@@ -27,5 +27,18 @@
   <ItemGroup>
 	<ProjectReference Include="..\..\src\EntityFrameworkCore.DataEncryption\EntityFrameworkCore.DataEncryption.csproj" />
   </ItemGroup>
+	
+	<ItemGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,6)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[3.1,6)" />
+	</ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net5.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5,)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[5,)" />
+	</ItemGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net6.0')">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6,)" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
I've added project references in the .csproj files: `src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj` to allow for multiple target platforms, including .net standard 2.0, .net 5.0 and .net 6.0.

I've done the same on the `test/EntityFrameworkCore.DataEncryption.Test/EntityFrameworkCore.DataEncryption.Test.csproj` file to allow for them to work with the new version of .net and the new ef core, as well as the previous ones.

After doing these changes, I ran the tests and they all passed with flying colors in both .net 5.0 and .net 6.0. I couldn't test on .net core 3.1 since the tests use features that are not available in c#8.0.

Finally I incremented the version to 3.0.1-dev so that you could after increment to 3.0.1 with the new changes, and once you've looked over the changes and agreed with them, as well made sure that it won't break support for older versions of EF core (which it shouldn't).

![image](https://user-images.githubusercontent.com/20151415/141647487-8ae9ec64-7a6e-466d-b2b9-6fc7e7b51efd.png)
