### PR TITLE
Add support for the EF Core 7 while targeting .NET 6

### DIFF
--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -35,7 +35,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,6)" />
 	</ItemGroup>
 	<ItemGroup Condition="('$(TargetFramework)' == 'net6.0')">
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,7]" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,8)" />
 	</ItemGroup>
 	<ItemGroup Condition="('$(TargetFramework)' == 'net7.0')">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7,)" />

--- a/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
+++ b/src/EntityFrameworkCore.DataEncryption/EntityFrameworkCore.DataEncryption.csproj
@@ -35,7 +35,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,6)" />
 	</ItemGroup>
 	<ItemGroup Condition="('$(TargetFramework)' == 'net6.0')">
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,7)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6,7]" />
 	</ItemGroup>
 	<ItemGroup Condition="('$(TargetFramework)' == 'net7.0')">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7,)" />


### PR DESCRIPTION
Since EF Core 7 is also [targeting](https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-7.0/whatsnew) .net 6, it would be really nice to include it into allowed versions list