### PR TITLE
Decrypt: check for null values to avoid exception on Encoding.UTF8.GetString

### DIFF
--- a/src/EntityFrameworkCore.DataEncryption/Internal/EncryptionConverter.cs
+++ b/src/EntityFrameworkCore.DataEncryption/Internal/EncryptionConverter.cs
@@ -62,7 +62,7 @@ internal sealed class EncryptionConverter<TModel, TProvider> : ValueConverter<TM
         byte[] decryptedRawBytes = encryptionProvider.Decrypt(inputData);
         object decryptedData = null;
 
-        if (destinationType == typeof(string))
+        if (decryptedRawBytes != null && destinationType == typeof(string))
         {
             decryptedData = Encoding.UTF8.GetString(decryptedRawBytes).Trim('\0');
         }


### PR DESCRIPTION
Fix: provider might return null (for decryptedRawBytes variable) when decrypting data which leads to an exception here 

var decryptedData = Encoding.UTF8.GetString(decryptedRawBytes).Trim('\0');